### PR TITLE
Add mythic-vibe CLI package with workflow, codex bridge, and method import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+# Mythic Vibe CLI
+
+An open-source vibe-coding CLI that **automatically follows the Mythic Engineering method** and is intentionally beginner-friendly.
+
+Canonical Mythic Engineering source:
+- https://github.com/hrabanazviking/Mythic-Engineering
+
+## Why this is better now
+
+This now supports a **ChatGPT Plus ($20/mo) friendly Codex workflow**:
+- Generate a structured prompt packet from your local project context.
+- Paste it into ChatGPT/Codex.
+- Log the assistant output back into Mythic tracking.
+
+No API key is required for this copy/paste flow.
+
+## What this CLI enforces
+
+- Architecture-first scaffolding aligned to Mythic Engineering docs.
+- Required documentation starter files (`docs/`, `tasks/`, `MYTHIC_ENGINEERING.md`, `mythic/`).
+- A phase-based execution loop:
+  `intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
+- Progress tracking so you can keep collaborators in the loop with structured updates.
+
+## Install
+
+```bash
+pip install -e .
+```
+
+## Quick start (new project)
+
+```bash
+mythic-vibe init --goal "Build a beginner-friendly TODO app" --noob
+```
+
+This creates a Mythic-oriented scaffold including:
+- `docs/PHILOSOPHY.md`
+- `docs/ARCHITECTURE.md`
+- `docs/DOMAIN_MAP.md`
+- `docs/DATA_FLOW.md`
+- `docs/DEVLOG.md`
+- `tasks/current_GOALS.md`
+- `mythic/plan.md`
+- `mythic/loop.md`
+- `mythic/status.json`
+- `MYTHIC_ENGINEERING.md`
+
+## Import full Mythic markdown corpus
+
+To import **all `.md` files** from the canonical Mythic Engineering repo into your project:
+
+```bash
+mythic-vibe import-md
+```
+
+By default this writes into `docs/mythic_source/` and creates an index file:
+- `docs/mythic_source/_import_index.json`
+
+Custom destination:
+
+```bash
+mythic-vibe import-md --target docs/reference/mythic
+```
+
+## ChatGPT Plus / Codex bridge flow
+
+1) Generate a packet:
+
+```bash
+mythic-vibe codex-pack \
+  --phase plan \
+  --task "Implement the CLI command parser and file templates" \
+  --audience beginner
+```
+
+2) Open `mythic/codex_prompt.md` and paste the `Prompt To Paste` section into ChatGPT/Codex.
+
+3) Log the response summary:
+
+```bash
+mythic-vibe codex-log --phase build --response "Implemented parser with subcommands and docs updates"
+```
+
+4) Check current status:
+
+```bash
+mythic-vibe status
+```
+
+## Manual check-ins (without codex-log)
+
+```bash
+mythic-vibe checkin --phase intent --update "Defined user outcome and anti-goals"
+```
+
+## Method sync commands
+
+Sync latest method notes from GitHub:
+
+```bash
+mythic-vibe sync
+```
+
+Print currently loaded method notes:
+
+```bash
+mythic-vibe method
+```
+
+## License
+
+MIT

--- a/mythic_vibe_cli/__init__.py
+++ b/mythic_vibe_cli/__init__.py
@@ -1,0 +1,4 @@
+"""Mythic Vibe CLI package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/mythic_vibe_cli/cli.py
+++ b/mythic_vibe_cli/cli.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from . import __version__
+from .codex_bridge import CodexBridge, CodexPacketRequest
+from .mythic_data import MethodStore
+from .workflow import MythicRunConfig, MythicWorkflow, PHASES
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mythic-vibe",
+        description="Mythic Engineering-aligned vibe coding CLI",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init_cmd = sub.add_parser("init", help="Initialize Mythic Engineering docs + workflow scaffolding")
+    init_cmd.add_argument("--goal", required=True, help="Plain language product goal")
+    init_cmd.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    init_cmd.add_argument("--noob", action="store_true", help="Enable beginner-friendly guidance")
+
+    start = sub.add_parser("start", help="Alias of `init`")
+    start.add_argument("--goal", required=True, help="Plain language product goal")
+    start.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    start.add_argument("--noob", action="store_true", help="Enable beginner-friendly guidance")
+
+    checkin = sub.add_parser("checkin", help="Log a Mythic phase update and advance tracking")
+    checkin.add_argument("--phase", required=True, choices=PHASES, help="Current Mythic phase")
+    checkin.add_argument("--update", required=True, help="Short progress update")
+    checkin.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    status = sub.add_parser("status", help="Show current Mythic progress summary")
+    status.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    import_md = sub.add_parser("import-md", help="Import all Markdown files from Mythic Engineering repo")
+    import_md.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    import_md.add_argument(
+        "--target",
+        default="docs/mythic_source",
+        help="Target folder inside project for imported files (default: docs/mythic_source)",
+    )
+
+    codex_pack = sub.add_parser(
+        "codex-pack",
+        help="Generate a copy/paste-ready prompt packet for ChatGPT Plus/Codex users",
+    )
+    codex_pack.add_argument("--task", required=True, help="Specific coding task for Codex")
+    codex_pack.add_argument("--phase", required=True, choices=PHASES, help="Current Mythic phase")
+    codex_pack.add_argument("--audience", default="beginner", help="Audience level: beginner/intermediate/advanced")
+    codex_pack.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    codex_pack.add_argument("--out", default=None, help="Output file path (default: <project>/mythic/codex_prompt.md)")
+
+    codex_log = sub.add_parser(
+        "codex-log",
+        help="Record a check-in update after receiving a response from ChatGPT/Codex",
+    )
+    codex_log.add_argument("--phase", required=True, choices=PHASES, help="Current Mythic phase")
+    codex_log.add_argument("--response", required=True, help="One-line summary from Codex response")
+    codex_log.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    sub.add_parser("sync", help="Sync Mythic Engineering method notes from GitHub")
+    sub.add_parser("method", help="Print active Mythic method notes")
+
+    return parser
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+
+    store = MethodStore()
+    method = store.load()
+    workflow = MythicWorkflow(root)
+    created = workflow.init_project(
+        MythicRunConfig(goal=args.goal, noob_mode=args.noob),
+        method_source=method.source,
+    )
+
+    print("Mythic Engineering project scaffolding ready.")
+    print(f"Method source: {method.source}")
+    if created:
+        print("Created files:")
+        for path in created:
+            print(f"- {path}")
+    else:
+        print("No new files were created (scaffold already existed).")
+
+    print("Next step: run `mythic-vibe import-md` to copy the full Mythic markdown corpus locally.")
+    return 0
+
+
+def cmd_checkin(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    workflow = MythicWorkflow(root)
+
+    try:
+        status_file, devlog_file = workflow.check_in(phase=args.phase, update=args.update)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print("Mythic check-in recorded.")
+    print(f"- Status: {status_file}")
+    print(f"- Devlog: {devlog_file}")
+    print("- Summary:")
+    print(workflow.status_summary())
+    return 0
+
+
+def cmd_import_md(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    target = root / args.target
+    store = MethodStore()
+    try:
+        written = store.import_all_markdown(target)
+    except Exception as exc:  # noqa: BLE001 - surface remote import issues in CLI.
+        print(f"Import failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("Imported Mythic Engineering markdown files.")
+    print(f"- Destination: {target}")
+    print(f"- Files imported: {len(written)}")
+    print(f"- Index: {target / '_import_index.json'}")
+    return 0
+
+
+def cmd_codex_pack(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    bridge = CodexBridge(root)
+    packet = bridge.create_packet(
+        request=CodexPacketRequest(task=args.task, phase=args.phase, audience=args.audience),
+        out_file=Path(args.out).resolve() if args.out else None,
+    )
+    print("Codex packet generated.")
+    print(f"- File: {packet}")
+    print("Paste the 'Prompt To Paste' section into ChatGPT/Codex.")
+    return 0
+
+
+def cmd_codex_log(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    workflow = MythicWorkflow(root)
+    status_file, devlog_file = workflow.check_in(phase=args.phase, update=args.response)
+    print("Codex response logged into Mythic workflow.")
+    print(f"- Status: {status_file}")
+    print(f"- Devlog: {devlog_file}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    workflow = MythicWorkflow(root)
+    print(workflow.status_summary())
+    return 0
+
+
+def cmd_sync() -> int:
+    store = MethodStore()
+    try:
+        bundle = store.sync()
+    except Exception as exc:  # noqa: BLE001 - CLI should show actionable message and continue.
+        print(f"Sync failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("Synced Mythic method notes.")
+    print(f"Source: {bundle.source}")
+    print(f"Cache: {store.cache_file}")
+    return 0
+
+
+def cmd_method() -> int:
+    store = MethodStore()
+    bundle = store.load()
+    print(f"Method source: {bundle.source}")
+    print("=" * 72)
+    print(bundle.content)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command in {"init", "start"}:
+        return cmd_init(args)
+    if args.command == "checkin":
+        return cmd_checkin(args)
+    if args.command == "import-md":
+        return cmd_import_md(args)
+    if args.command == "codex-pack":
+        return cmd_codex_pack(args)
+    if args.command == "codex-log":
+        return cmd_codex_log(args)
+    if args.command == "status":
+        return cmd_status(args)
+    if args.command == "sync":
+        return cmd_sync()
+    if args.command == "method":
+        return cmd_method()
+
+    parser.error("Unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mythic_vibe_cli/codex_bridge.py
+++ b/mythic_vibe_cli/codex_bridge.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import textwrap
+
+
+@dataclass
+class CodexPacketRequest:
+    task: str
+    phase: str
+    audience: str
+
+
+class CodexBridge:
+    def __init__(self, root: Path):
+        self.root = root
+        self.docs_dir = root / "docs"
+        self.tasks_dir = root / "tasks"
+        self.mythic_dir = root / "mythic"
+
+    def create_packet(self, request: CodexPacketRequest, out_file: Path | None = None) -> Path:
+        out = out_file or (self.mythic_dir / "codex_prompt.md")
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(self._render_packet(request), encoding="utf-8")
+        return out
+
+    def _read_optional(self, path: Path, fallback: str = "(missing)") -> str:
+        if not path.exists():
+            return fallback
+        return path.read_text(encoding="utf-8")
+
+    def _safe_excerpt(self, text: str, limit: int = 1800) -> str:
+        compact = text.strip()
+        if len(compact) <= limit:
+            return compact
+        return compact[:limit] + "\n... [truncated by mythic-vibe]"
+
+    def _status_snapshot(self) -> str:
+        path = self.mythic_dir / "status.json"
+        if not path.exists():
+            return "No status.json found."
+        state = json.loads(path.read_text(encoding="utf-8"))
+        return json.dumps(
+            {
+                "goal": state.get("goal"),
+                "current_phase": state.get("current_phase"),
+                "completed_phases": state.get("completed_phases", []),
+                "last_update": state.get("last_update"),
+            },
+            indent=2,
+        )
+
+    def _render_packet(self, request: CodexPacketRequest) -> str:
+        goals = self._safe_excerpt(self._read_optional(self.tasks_dir / "current_GOALS.md"))
+        architecture = self._safe_excerpt(self._read_optional(self.docs_dir / "ARCHITECTURE.md"))
+        plan = self._safe_excerpt(self._read_optional(self.mythic_dir / "plan.md"))
+        loop = self._safe_excerpt(self._read_optional(self.mythic_dir / "loop.md"))
+        status = self._status_snapshot()
+
+        return textwrap.dedent(
+            f"""
+            # Codex Prompt Packet (ChatGPT Plus Friendly)
+
+            This packet is generated for users on a $20 ChatGPT Plus account.
+            Paste the section below into ChatGPT (or Codex in ChatGPT) to continue work.
+
+            ## Prompt To Paste
+
+            You are my Mythic Engineering coding copilot.
+            Use this strict operating sequence:
+            1) Restate intent and constraints.
+            2) Propose architecture-aware plan.
+            3) Suggest smallest safe code change.
+            4) Suggest verification commands.
+            5) Suggest a concise check-in update.
+
+            My audience level: {request.audience}
+            Current phase: {request.phase}
+            Task request: {request.task}
+
+            Project context below:
+
+            ### STATUS SNAPSHOT
+            ```json
+            {status}
+            ```
+
+            ### GOALS
+            ```markdown
+            {goals}
+            ```
+
+            ### ARCHITECTURE
+            ```markdown
+            {architecture}
+            ```
+
+            ### PLAN
+            ```markdown
+            {plan}
+            ```
+
+            ### LOOP NOTES
+            ```markdown
+            {loop}
+            ```
+
+            Return output in this exact format:
+
+            ## Mythic Plan Update
+            <bullet points>
+
+            ## File Changes
+            <ordered steps>
+
+            ## Verification
+            <commands + expected outputs>
+
+            ## Checkin
+            Phase: {request.phase}
+            Update: <one sentence for mythic-vibe checkin>
+            """
+        ).strip() + "\n"

--- a/mythic_vibe_cli/mythic_data.py
+++ b/mythic_vibe_cli/mythic_data.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import textwrap
+import urllib.error
+import urllib.request
+
+from dataclasses import dataclass
+
+CANONICAL_REPO = "https://github.com/hrabanazviking/Mythic-Engineering"
+CANONICAL_README_RAW = (
+    "https://raw.githubusercontent.com/hrabanazviking/Mythic-Engineering/main/README.md"
+)
+CANONICAL_TREE_API = "https://api.github.com/repos/hrabanazviking/Mythic-Engineering/git/trees/main?recursive=1"
+CANONICAL_RAW_BASE = "https://raw.githubusercontent.com/hrabanazviking/Mythic-Engineering/main/"
+
+DEFAULT_METHOD_NOTES = textwrap.dedent(
+    """
+    Mythic Engineering Vibe Loop (fallback profile)
+
+    1) Intent
+       - Define what to build in one clear sentence.
+       - Define the user outcome first.
+
+    2) Constraints
+       - List known constraints (time, stack, risk, quality bar).
+       - Prefer simpler architecture when uncertain.
+
+    3) Plan
+       - Break into smallest valuable milestones.
+       - State assumptions before coding.
+
+    4) Build
+       - Implement one milestone at a time.
+       - Keep the code understandable for future maintainers.
+
+    5) Verify
+       - Run checks/tests after each milestone.
+       - Confirm result matches intent, not just that code runs.
+
+    6) Reflect
+       - Document what changed and why.
+       - Capture follow-up improvements and risks.
+    """
+).strip()
+
+
+@dataclass
+class MethodBundle:
+    source: str
+    content: str
+
+
+class MethodStore:
+    def __init__(self, app_home: Path | None = None):
+        self.app_home = app_home or Path(os.environ.get("MYTHIC_HOME", Path.home() / ".mythic-vibe"))
+        self.app_home.mkdir(parents=True, exist_ok=True)
+        self.cache_file = self.app_home / "method_cache.json"
+
+    def sync(self, timeout: int = 10) -> MethodBundle:
+        req = urllib.request.Request(CANONICAL_README_RAW, headers={"User-Agent": "mythic-vibe-cli/0.1"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            content = resp.read().decode("utf-8", errors="replace")
+
+        bundle = MethodBundle(source=CANONICAL_REPO, content=content)
+        self.cache_file.write_text(json.dumps(bundle.__dict__, indent=2), encoding="utf-8")
+        return bundle
+
+    def load(self) -> MethodBundle:
+        if self.cache_file.exists():
+            data = json.loads(self.cache_file.read_text(encoding="utf-8"))
+            return MethodBundle(source=data["source"], content=data["content"])
+
+        try:
+            return self.sync()
+        except (urllib.error.URLError, TimeoutError):
+            return MethodBundle(source="fallback", content=DEFAULT_METHOD_NOTES)
+
+    def import_all_markdown(self, target_dir: Path, timeout: int = 20) -> list[Path]:
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        req = urllib.request.Request(CANONICAL_TREE_API, headers={"User-Agent": "mythic-vibe-cli/0.1"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            tree_payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+
+        items = tree_payload.get("tree", [])
+        md_paths = [item["path"] for item in items if item.get("type") == "blob" and item.get("path", "").lower().endswith(".md")]
+
+        written: list[Path] = []
+        for rel_path in md_paths:
+            raw_url = f"{CANONICAL_RAW_BASE}{rel_path}"
+            out_path = target_dir / rel_path
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+
+            file_req = urllib.request.Request(raw_url, headers={"User-Agent": "mythic-vibe-cli/0.1"})
+            with urllib.request.urlopen(file_req, timeout=timeout) as file_resp:
+                content = file_resp.read().decode("utf-8", errors="replace")
+
+            out_path.write_text(content, encoding="utf-8")
+            written.append(out_path)
+
+        index = target_dir / "_import_index.json"
+        index.write_text(
+            json.dumps(
+                {
+                    "source": CANONICAL_REPO,
+                    "markdown_files": len(written),
+                    "paths": [str(p.relative_to(target_dir)) for p in written],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        return written

--- a/mythic_vibe_cli/workflow.py
+++ b/mythic_vibe_cli/workflow.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import textwrap
+
+
+PHASES = [
+    "intent",
+    "constraints",
+    "architecture",
+    "plan",
+    "build",
+    "verify",
+    "reflect",
+]
+
+
+@dataclass
+class MythicRunConfig:
+    goal: str
+    noob_mode: bool
+
+
+class MythicWorkflow:
+    def __init__(self, root: Path):
+        self.root = root
+        self.docs_dir = root / "docs"
+        self.tasks_dir = root / "tasks"
+        self.mythic_dir = root / "mythic"
+
+    def init_project(self, config: MythicRunConfig, method_source: str) -> list[Path]:
+        self.docs_dir.mkdir(parents=True, exist_ok=True)
+        self.tasks_dir.mkdir(parents=True, exist_ok=True)
+        self.mythic_dir.mkdir(parents=True, exist_ok=True)
+        (self.docs_dir / "DECISIONS").mkdir(parents=True, exist_ok=True)
+
+        files: dict[Path, str] = {
+            self.root / "MYTHIC_ENGINEERING.md": self._mythic_engineering_note(method_source),
+            self.docs_dir / "PHILOSOPHY.md": self._philosophy_template(config.goal),
+            self.docs_dir / "ARCHITECTURE.md": self._architecture_template(),
+            self.docs_dir / "DOMAIN_MAP.md": self._domain_map_template(),
+            self.docs_dir / "DATA_FLOW.md": self._data_flow_template(),
+            self.docs_dir / "DEVLOG.md": self._devlog_template(),
+            self.tasks_dir / "current_GOALS.md": self._goals_template(config.goal),
+            self.mythic_dir / "plan.md": self._plan_template(config.goal, config.noob_mode),
+            self.mythic_dir / "loop.md": self._loop_template(config.noob_mode),
+            self.mythic_dir / "status.json": self._status_template(config.goal),
+        }
+
+        written: list[Path] = []
+        for path, content in files.items():
+            if not path.exists():
+                path.write_text(content, encoding="utf-8")
+                written.append(path)
+
+        return written
+
+    def check_in(self, phase: str, update: str) -> tuple[Path, Path]:
+        normalized = phase.strip().lower()
+        if normalized not in PHASES:
+            valid = ", ".join(PHASES)
+            raise ValueError(f"Invalid phase '{phase}'. Choose one of: {valid}")
+
+        self.mythic_dir.mkdir(parents=True, exist_ok=True)
+        status_path = self.mythic_dir / "status.json"
+        devlog_path = self.docs_dir / "DEVLOG.md"
+        self.docs_dir.mkdir(parents=True, exist_ok=True)
+
+        if status_path.exists():
+            state = json.loads(status_path.read_text(encoding="utf-8"))
+        else:
+            state = json.loads(self._status_template("unspecified goal"))
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+        state["current_phase"] = normalized
+        state["completed_phases"] = sorted(set(state.get("completed_phases", []) + [normalized]))
+        state["last_update"] = timestamp
+        history = state.setdefault("history", [])
+        history.append({"time": timestamp, "phase": normalized, "update": update})
+        status_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+        if not devlog_path.exists():
+            devlog_path.write_text(self._devlog_template(), encoding="utf-8")
+
+        with devlog_path.open("a", encoding="utf-8") as fh:
+            fh.write(f"\n## {timestamp} | {normalized.title()}\n- {update}\n")
+
+        return status_path, devlog_path
+
+    def status_summary(self) -> str:
+        status_path = self.mythic_dir / "status.json"
+        if not status_path.exists():
+            return "No Mythic status found. Run `mythic-vibe init --goal \"...\"` first."
+
+        state = json.loads(status_path.read_text(encoding="utf-8"))
+        completed = state.get("completed_phases", [])
+        progress = int((len(completed) / len(PHASES)) * 100)
+        return textwrap.dedent(
+            f"""
+            Goal: {state.get('goal', 'n/a')}
+            Current phase: {state.get('current_phase', 'intent')}
+            Progress: {progress}% ({len(completed)}/{len(PHASES)} phases touched)
+            Last update: {state.get('last_update', 'n/a')}
+            Next suggested phase: {self._next_phase(completed)}
+            """
+        ).strip()
+
+    def _next_phase(self, completed: list[str]) -> str:
+        for phase in PHASES:
+            if phase not in completed:
+                return phase
+        return "reflect (all phases completed at least once)"
+
+    def _mythic_engineering_note(self, method_source: str) -> str:
+        return textwrap.dedent(
+            f"""
+            # MYTHIC_ENGINEERING
+
+            This repository is being developed using Mythic Engineering practices.
+
+            Canonical source: {method_source}
+
+            Core loop enforced by this CLI:
+            1. Intent
+            2. Constraints
+            3. Architecture
+            4. Plan
+            5. Build
+            6. Verify
+            7. Reflect
+            """
+        ).strip() + "\n"
+
+    def _plan_template(self, goal: str, noob_mode: bool) -> str:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+        beginner_tips = "Enabled" if noob_mode else "Disabled"
+        return textwrap.dedent(
+            f"""
+            # Mythic Plan
+
+            - Created: {now}
+            - Goal: {goal}
+            - Beginner guidance: {beginner_tips}
+
+            ## 1) Intent
+            Define the user outcome in one sentence.
+
+            ## 2) Constraints
+            - Time box:
+            - Tech constraints:
+            - Quality / safety constraints:
+
+            ## 3) Architecture
+            - What subsystem owns this change?
+            - What must remain true (invariants)?
+
+            ## 4) Milestones
+            - [ ] Milestone 1:
+            - [ ] Milestone 2:
+            - [ ] Milestone 3:
+
+            ## 5) Verification strategy
+            - Command/check:
+            - Expected outcome:
+
+            ## 6) Reflection
+            - What worked:
+            - What to improve:
+            """
+        ).strip() + "\n"
+
+    def _loop_template(self, noob_mode: bool) -> str:
+        help_line = (
+            "For each phase, write one plain-language sentence first, then technical detail."
+            if noob_mode
+            else "Write concise notes for each phase."
+        )
+        phases_md = "\n".join(f"## {idx + 1}. {name.title()}\n- Notes:\n" for idx, name in enumerate(PHASES))
+        return textwrap.dedent(
+            f"""
+            # Mythic Execution Loop
+
+            {help_line}
+
+            {phases_md}
+            """
+        ).strip() + "\n"
+
+    def _status_template(self, goal: str) -> str:
+        return json.dumps(
+            {
+                "goal": goal,
+                "current_phase": "intent",
+                "completed_phases": [],
+                "last_update": None,
+                "history": [],
+            },
+            indent=2,
+        )
+
+    def _philosophy_template(self, goal: str) -> str:
+        return textwrap.dedent(
+            f"""
+            # Philosophy
+
+            ## Deep intent
+            Build {goal} as a coherent, maintainable system.
+
+            ## Values
+            - architecture before patching
+            - explicit ownership and boundaries
+            - documentation as continuity memory
+            - test and verify every meaningful change
+
+            ## Anti-goals
+            - random prompt spam
+            - hidden logic and undocumented coupling
+            - shipping changes without verification
+            """
+        ).strip() + "\n"
+
+    def _architecture_template(self) -> str:
+        return textwrap.dedent(
+            """
+            # Architecture
+
+            ## Subsystems
+            - Interface layer
+            - Domain logic layer
+            - Data / persistence layer
+            - Integrations layer
+
+            ## Boundaries
+            Describe what each subsystem owns and does not own.
+
+            ## Invariants
+            List truths that must remain true during refactors.
+            """
+        ).strip() + "\n"
+
+    def _domain_map_template(self) -> str:
+        return textwrap.dedent(
+            """
+            # Domain Map
+
+            ## Core domains
+            - Domain A:
+            - Domain B:
+
+            ## Ownership
+            For each domain, define responsibilities and interfaces.
+            """
+        ).strip() + "\n"
+
+    def _data_flow_template(self) -> str:
+        return textwrap.dedent(
+            """
+            # Data Flow
+
+            ## Input -> Processing -> Output
+            - Input source:
+            - Validation:
+            - Transformation:
+            - Storage / output:
+
+            ## Side effects
+            Document external effects (I/O, network, file writes).
+            """
+        ).strip() + "\n"
+
+    def _goals_template(self, goal: str) -> str:
+        return textwrap.dedent(
+            f"""
+            # Current Goals
+
+            ## Outcome
+            {goal}
+
+            ## Acceptance criteria
+            - [ ] Criterion 1
+            - [ ] Criterion 2
+            - [ ] Criterion 3
+
+            ## Risks
+            - Risk 1
+            - Risk 2
+            """
+        ).strip() + "\n"
+
+    def _devlog_template(self) -> str:
+        return textwrap.dedent(
+            """
+            # Devlog
+
+            Chronological change notes and reasons.
+            """
+        ).strip() + "\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mythic-vibe-cli"
+version = "0.1.0"
+description = "Beginner-friendly CLI that enforces Mythic Engineering vibe-coding workflow"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+  { name = "Mythic Vibe Contributors" }
+]
+keywords = ["cli", "vibe-coding", "mythic-engineering", "developer-tools"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent"
+]
+
+[project.urls]
+Homepage = "https://github.com/hrabanazviking/Mythic-Engineering"
+
+[project.scripts]
+mythic-vibe = "mythic_vibe_cli.cli:main"
+
+[tool.setuptools]
+packages = ["mythic_vibe_cli"]
+


### PR DESCRIPTION
### Motivation
- Provide a beginner-friendly CLI that enforces the Mythic Engineering phase-based workflow and scaffolds project documentation and tracking files.
- Enable a ChatGPT Plus / Codex copy/paste bridge to generate context-rich prompt packets from local project state.
- Allow importing the canonical Mythic Engineering markdown corpus and caching method notes locally for offline use.

### Description
- Add a new Python package `mythic_vibe_cli` with `cli.py` implementing the `mythic-vibe` entrypoint and subcommands such as `init`, `checkin`, `import-md`, `codex-pack`, `codex-log`, `status`, `sync`, and `method`.
- Implement `workflow.py` which creates project scaffolding, maintains `status.json` and `DEVLOG.md`, and provides `MythicWorkflow` operations including `init_project`, `check_in`, and `status_summary`.
- Implement `mythic_data.py` to sync and cache method notes from the canonical repo and to `import_all_markdown` into a target folder, and add `codex_bridge.py` to render a copy/paste Codex prompt packet from local files.
- Add packaging and metadata via `pyproject.toml`, a project `README.md` describing usage and flows, and a `.gitignore` for Python artifacts.

### Testing
- No automated tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cd8d1e0c8325a187f8c08c430352)