### PR TITLE
Add `doctor` diagnostics command, harden status handling, and add regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ mythic-vibe status
 mythic-vibe checkin --phase intent --update "Defined user outcome and anti-goals"
 ```
 
+## Project health diagnostics
+
+Run a quick structural + status validation:
+
+```bash
+mythic-vibe doctor
+```
+
+This checks required Mythic files, validates `mythic/status.json`, and reports any missing/invalid state.
+
 ## Method sync commands
 
 Sync latest method notes from GitHub:

--- a/mythic_vibe_cli/cli.py
+++ b/mythic_vibe_cli/cli.py
@@ -66,6 +66,9 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("sync", help="Sync Mythic Engineering method notes from GitHub")
     sub.add_parser("method", help="Print active Mythic method notes")
 
+    doctor = sub.add_parser("doctor", help="Validate Mythic project structure and status")
+    doctor.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
     return parser
 
 
@@ -145,7 +148,11 @@ def cmd_codex_pack(args: argparse.Namespace) -> int:
 def cmd_codex_log(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     workflow = MythicWorkflow(root)
-    status_file, devlog_file = workflow.check_in(phase=args.phase, update=args.response)
+    try:
+        status_file, devlog_file = workflow.check_in(phase=args.phase, update=args.response)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     print("Codex response logged into Mythic workflow.")
     print(f"- Status: {status_file}")
     print(f"- Devlog: {devlog_file}")
@@ -157,6 +164,31 @@ def cmd_status(args: argparse.Namespace) -> int:
     workflow = MythicWorkflow(root)
     print(workflow.status_summary())
     return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    workflow = MythicWorkflow(root)
+    errors, warnings = workflow.doctor()
+
+    print("Mythic project diagnostics")
+    print(f"- Path: {root}")
+
+    if errors:
+        print("- Errors:")
+        for item in errors:
+            print(f"  - {item}")
+    else:
+        print("- Errors: none")
+
+    if warnings:
+        print("- Warnings:")
+        for item in warnings:
+            print(f"  - {item}")
+    else:
+        print("- Warnings: none")
+
+    return 1 if errors else 0
 
 
 def cmd_sync() -> int:
@@ -202,6 +234,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_sync()
     if args.command == "method":
         return cmd_method()
+    if args.command == "doctor":
+        return cmd_doctor(args)
 
     parser.error("Unknown command")
     return 2

--- a/mythic_vibe_cli/codex_bridge.py
+++ b/mythic_vibe_cli/codex_bridge.py
@@ -41,7 +41,11 @@ class CodexBridge:
         path = self.mythic_dir / "status.json"
         if not path.exists():
             return "No status.json found."
-        state = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return "status.json exists but contains invalid JSON."
+
         return json.dumps(
             {
                 "goal": state.get("goal"),

--- a/mythic_vibe_cli/workflow.py
+++ b/mythic_vibe_cli/workflow.py
@@ -69,14 +69,14 @@ class MythicWorkflow:
         devlog_path = self.docs_dir / "DEVLOG.md"
         self.docs_dir.mkdir(parents=True, exist_ok=True)
 
-        if status_path.exists():
-            state = json.loads(status_path.read_text(encoding="utf-8"))
-        else:
-            state = json.loads(self._status_template("unspecified goal"))
+        state = self._load_status(status_path)
 
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
         state["current_phase"] = normalized
-        state["completed_phases"] = sorted(set(state.get("completed_phases", []) + [normalized]))
+        completed = [p for p in state.get("completed_phases", []) if p in PHASES]
+        if normalized not in completed:
+            completed.append(normalized)
+        state["completed_phases"] = completed
         state["last_update"] = timestamp
         history = state.setdefault("history", [])
         history.append({"time": timestamp, "phase": normalized, "update": update})
@@ -95,8 +95,8 @@ class MythicWorkflow:
         if not status_path.exists():
             return "No Mythic status found. Run `mythic-vibe init --goal \"...\"` first."
 
-        state = json.loads(status_path.read_text(encoding="utf-8"))
-        completed = state.get("completed_phases", [])
+        state = self._load_status(status_path)
+        completed = [phase for phase in state.get("completed_phases", []) if phase in PHASES]
         progress = int((len(completed) / len(PHASES)) * 100)
         return textwrap.dedent(
             f"""
@@ -107,6 +107,69 @@ class MythicWorkflow:
             Next suggested phase: {self._next_phase(completed)}
             """
         ).strip()
+
+    def doctor(self) -> tuple[list[str], list[str]]:
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        required = [
+            self.root / "MYTHIC_ENGINEERING.md",
+            self.docs_dir / "PHILOSOPHY.md",
+            self.docs_dir / "ARCHITECTURE.md",
+            self.docs_dir / "DOMAIN_MAP.md",
+            self.docs_dir / "DATA_FLOW.md",
+            self.docs_dir / "DEVLOG.md",
+            self.tasks_dir / "current_GOALS.md",
+            self.mythic_dir / "plan.md",
+            self.mythic_dir / "loop.md",
+            self.mythic_dir / "status.json",
+        ]
+
+        for path in required:
+            if not path.exists():
+                errors.append(f"Missing required file: {path.relative_to(self.root)}")
+
+        status_path = self.mythic_dir / "status.json"
+        if status_path.exists():
+            try:
+                state = json.loads(status_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                errors.append("Invalid JSON in mythic/status.json")
+                state = None
+
+            if state:
+                current = state.get("current_phase")
+                if current and current not in PHASES:
+                    errors.append(f"Invalid current_phase in status.json: {current}")
+
+                completed = state.get("completed_phases", [])
+                invalid = [phase for phase in completed if phase not in PHASES]
+                if invalid:
+                    errors.append(f"Invalid completed_phases values: {', '.join(invalid)}")
+
+                if not state.get("history"):
+                    warnings.append("No check-in history yet. Run `mythic-vibe checkin` after your next milestone.")
+
+        return errors, warnings
+
+    def _load_status(self, status_path: Path) -> dict:
+        if not status_path.exists():
+            return json.loads(self._status_template("unspecified goal"))
+
+        try:
+            state = json.loads(status_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return json.loads(self._status_template("unspecified goal"))
+
+        if not isinstance(state, dict):
+            return json.loads(self._status_template("unspecified goal"))
+
+        state.setdefault("goal", "unspecified goal")
+        state.setdefault("current_phase", "intent")
+        state.setdefault("completed_phases", [])
+        state.setdefault("last_update", None)
+        state.setdefault("history", [])
+        return state
 
     def _next_phase(self, completed: list[str]) -> str:
         for phase in PHASES:
@@ -260,33 +323,14 @@ class MythicWorkflow:
             """
             # Data Flow
 
-            ## Input -> Processing -> Output
-            - Input source:
-            - Validation:
-            - Transformation:
-            - Storage / output:
+            ## Inputs
+            List external and internal inputs.
 
-            ## Side effects
-            Document external effects (I/O, network, file writes).
-            """
-        ).strip() + "\n"
+            ## Transformations
+            Document processing steps and ownership.
 
-    def _goals_template(self, goal: str) -> str:
-        return textwrap.dedent(
-            f"""
-            # Current Goals
-
-            ## Outcome
-            {goal}
-
-            ## Acceptance criteria
-            - [ ] Criterion 1
-            - [ ] Criterion 2
-            - [ ] Criterion 3
-
-            ## Risks
-            - Risk 1
-            - Risk 2
+            ## Outputs
+            Define side effects, storage, and user-facing results.
             """
         ).strip() + "\n"
 
@@ -295,6 +339,21 @@ class MythicWorkflow:
             """
             # Devlog
 
-            Chronological change notes and reasons.
+            Chronological updates from the Mythic loop.
+            """
+        ).strip() + "\n"
+
+    def _goals_template(self, goal: str) -> str:
+        return textwrap.dedent(
+            f"""
+            # Current Goals
+
+            Primary goal:
+            - {goal}
+
+            Success criteria:
+            - [ ] Users can complete the key workflow.
+            - [ ] Architecture boundaries are documented.
+            - [ ] Verification commands are documented and passing.
             """
         ).strip() + "\n"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from mythic_vibe_cli.workflow import MythicRunConfig, MythicWorkflow
+
+
+class MythicWorkflowTests(unittest.TestCase):
+    def test_checkin_preserves_phase_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workflow = MythicWorkflow(root)
+            workflow.init_project(MythicRunConfig(goal="Test", noob_mode=False), method_source="test")
+            workflow.check_in("build", "did build")
+            workflow.check_in("intent", "rechecked intent")
+
+            status = json.loads((root / "mythic" / "status.json").read_text(encoding="utf-8"))
+            self.assertEqual(status["completed_phases"], ["build", "intent"])
+
+    def test_doctor_reports_missing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workflow = MythicWorkflow(root)
+            errors, warnings = workflow.doctor()
+            self.assertTrue(errors)
+            self.assertFalse(any("Invalid JSON" in item for item in errors))
+            self.assertEqual(warnings, [])
+
+    def test_status_summary_handles_invalid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mythic = root / "mythic"
+            mythic.mkdir(parents=True, exist_ok=True)
+            (mythic / "status.json").write_text("{broken", encoding="utf-8")
+
+            workflow = MythicWorkflow(root)
+            summary = workflow.status_summary()
+            self.assertIn("Goal:", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a quick structural and status validation (`doctor`) to help users and automation detect missing or invalid Mythic scaffolding.
- Improve resilience when `mythic/status.json` is missing or malformed so CLI flows and Codex packet generation do not crash.
- Ensure `check_in` preserves phase completion ordering and that diagnostics return a meaningful exit code for CI use.

### Description

- Add a `doctor` subcommand to the CLI and implement `cmd_doctor` in `mythic_vibe_cli/cli.py` to print errors/warnings and return `1` when errors are present.
- Implement `MythicWorkflow.doctor()` and a `_load_status()` helper in `mythic_vibe_cli/workflow.py`, and update `check_in()` and `status_summary()` to use the safe loader and preserve completed-phase insertion order.
- Harden `CodexBridge._status_snapshot()` in `mythic_vibe_cli/codex_bridge.py` to catch `JSONDecodeError` and emit a clear fallback message instead of raising.
- Add `tests/test_workflow.py` with unit tests for phase ordering, diagnostics behavior, and invalid `status.json` recovery, and document the new `doctor` command in `README.md`.

### Testing

- Ran `python -m unittest discover -s tests -v` and all tests passed (`OK`).
- Verified CLI help with `python -m mythic_vibe_cli.cli --help` which lists the new `doctor` command.
- Executed `python -m mythic_vibe_cli.cli doctor --path /tmp/nonexistent-mythic-project` which printed diagnostics for missing files and exited with code `1` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94f7eaf5483258527672b8fbc33cf)