### PR TITLE
Implement Mythic design rituals and project vision scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,21 @@ Print currently loaded method notes:
 mythic-vibe method
 ```
 
+## Ritual command aliases from the Mythic design doc
+
+The CLI now supports the design-doc style ritual commands in addition to existing commands:
+
+- `mythic imbue` (alias of `init`)
+- `mythic evoke` (alias of `codex-pack`)
+- `mythic scry` (alias of `doctor`)
+- `mythic weave`
+- `mythic prune`
+- `mythic heal`
+- `mythic oath`
+- `mythic grimoire add|list`
+- `mythic config set`
+- `mythic db migrate`
+
 ## License
 
 MIT

--- a/mythic_vibe_cli/cli.py
+++ b/mythic_vibe_cli/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 from pathlib import Path
 import sys
 
@@ -68,6 +69,55 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor = sub.add_parser("doctor", help="Validate Mythic project structure and status")
     doctor.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    # Mythic ritual aliases from design doc.
+    imbue = sub.add_parser("imbue", help="Initialize project vision and Mythic scaffolding")
+    imbue.add_argument("--goal", required=True, help="Plain language product goal")
+    imbue.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    imbue.add_argument("--noob", action="store_true", help="Enable beginner-friendly guidance")
+
+    evoke = sub.add_parser("evoke", help="Generate a Codex packet from an architecture-aware prompt")
+    evoke.add_argument("--task", required=True, help="Specific coding task for Codex")
+    evoke.add_argument("--phase", default="plan", choices=PHASES, help="Current Mythic phase (default: plan)")
+    evoke.add_argument("--audience", default="beginner", help="Audience level: beginner/intermediate/advanced")
+    evoke.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    evoke.add_argument("--out", default=None, help="Output file path (default: <project>/mythic/codex_prompt.md)")
+
+    scry = sub.add_parser("scry", help="Analyze project health and diagnostics")
+    scry.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    weave = sub.add_parser("weave", help="Record documentation synchronization checkpoint")
+    weave.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    prune = sub.add_parser("prune", help="Suggest dead-code pruning workflow")
+    prune.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    heal = sub.add_parser("heal", help="Guide a test-healing workflow")
+    heal.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    heal.add_argument("--failing-test", default="", help="Optional failing test identifier")
+
+    oath = sub.add_parser("oath", help="Display responsible AI usage oath")
+    oath.add_argument("--yes", action="store_true", help="Echo acceptance message after displaying the oath")
+
+    grimoire = sub.add_parser("grimoire", help="Manage plugins")
+    grimoire_sub = grimoire.add_subparsers(dest="grimoire_command", required=True)
+    grimoire_add = grimoire_sub.add_parser("add", help="Register a plugin entrypoint string")
+    grimoire_add.add_argument("plugin", help="Plugin entrypoint, e.g. package.module:Plugin")
+    grimoire_add.add_argument("--path", default=".", help="Project directory (default: current directory)")
+    grimoire_list = grimoire_sub.add_parser("list", help="List registered plugins")
+    grimoire_list.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    config = sub.add_parser("config", help="Manage configuration values")
+    config_sub = config.add_subparsers(dest="config_command", required=True)
+    config_set = config_sub.add_parser("set", help="Set a dotted configuration value")
+    config_set.add_argument("key", help="Dotted key, e.g. core.default_model")
+    config_set.add_argument("value", help="String value")
+    config_set.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    db = sub.add_parser("db", help="Database maintenance tasks")
+    db_sub = db.add_subparsers(dest="db_command", required=True)
+    db_migrate = db_sub.add_parser("migrate", help="Create/upgrade local weave database")
+    db_migrate.add_argument("--path", default=".", help="Project directory (default: current directory)")
 
     return parser
 
@@ -214,11 +264,115 @@ def cmd_method() -> int:
     return 0
 
 
+def cmd_oath(args: argparse.Namespace) -> int:
+    oath = "I understand that AI may generate incorrect or insecure code. I will review all changes before committing to the Sacred Grove."
+    print(oath)
+    if args.yes:
+        print("Oath accepted.")
+    return 0
+
+
+def cmd_grimoire(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    store_file = root / "mythic" / "plugins.json"
+    store_file.parent.mkdir(parents=True, exist_ok=True)
+    if store_file.exists():
+        import json
+
+        data = json.loads(store_file.read_text(encoding="utf-8"))
+    else:
+        data = {"plugins": []}
+
+    if args.grimoire_command == "add":
+        if args.plugin not in data["plugins"]:
+            data["plugins"].append(args.plugin)
+            import json
+
+            store_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            print(f"Registered plugin: {args.plugin}")
+        else:
+            print(f"Plugin already registered: {args.plugin}")
+        print(f"Registry: {store_file}")
+        return 0
+
+    plugins = data.get("plugins", [])
+    if not plugins:
+        print("No plugins registered.")
+        return 0
+    print("Registered plugins:")
+    for plugin in plugins:
+        print(f"- {plugin}")
+    return 0
+
+
+def cmd_config(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    config_file = root / "mythic" / "config.toml"
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    with config_file.open("a", encoding="utf-8") as fh:
+        fh.write(f'{args.key} = "{args.value}"\n')
+    print(f"Updated config: {config_file}")
+    print(f"- {args.key} = {args.value}")
+    return 0
+
+
+def cmd_db_migrate(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    db_path = root / "mythic" / "weave.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rituals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ritual TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+    print(f"Database migrated: {db_path}")
+    return 0
+
+
+def cmd_weave(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    workflow = MythicWorkflow(root)
+    try:
+        status_file, devlog_file = workflow.check_in(phase="reflect", update="Ran mythic weave doc synchronization checkpoint.")
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    print("Weave synchronization checkpoint recorded.")
+    print(f"- Status: {status_file}")
+    print(f"- Devlog: {devlog_file}")
+    return 0
+
+
+def cmd_prune(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    print("Prune ritual scaffold ready.")
+    print(f"- Project: {root}")
+    print("Next: run your linter/dead-code tool and remove one safe item at a time.")
+    return 0
+
+
+def cmd_heal(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    print("Heal ritual scaffold ready.")
+    print(f"- Project: {root}")
+    if args.failing_test:
+        print(f"- Target failing test: {args.failing_test}")
+    print("Next: reproduce the failure, patch minimally, then rerun tests.")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    if args.command in {"init", "start"}:
+    if args.command in {"init", "start", "imbue"}:
         return cmd_init(args)
     if args.command == "checkin":
         return cmd_checkin(args)
@@ -236,6 +390,24 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_method()
     if args.command == "doctor":
         return cmd_doctor(args)
+    if args.command == "evoke":
+        return cmd_codex_pack(args)
+    if args.command == "scry":
+        return cmd_doctor(args)
+    if args.command == "weave":
+        return cmd_weave(args)
+    if args.command == "prune":
+        return cmd_prune(args)
+    if args.command == "heal":
+        return cmd_heal(args)
+    if args.command == "oath":
+        return cmd_oath(args)
+    if args.command == "grimoire":
+        return cmd_grimoire(args)
+    if args.command == "config":
+        return cmd_config(args)
+    if args.command == "db":
+        return cmd_db_migrate(args)
 
     parser.error("Unknown command")
     return 2

--- a/mythic_vibe_cli/workflow.py
+++ b/mythic_vibe_cli/workflow.py
@@ -39,6 +39,7 @@ class MythicWorkflow:
 
         files: dict[Path, str] = {
             self.root / "MYTHIC_ENGINEERING.md": self._mythic_engineering_note(method_source),
+            self.root / "SYSTEM_VISION.md": self._vision_template(config.goal),
             self.docs_dir / "PHILOSOPHY.md": self._philosophy_template(config.goal),
             self.docs_dir / "ARCHITECTURE.md": self._architecture_template(),
             self.docs_dir / "DOMAIN_MAP.md": self._domain_map_template(),
@@ -114,6 +115,7 @@ class MythicWorkflow:
 
         required = [
             self.root / "MYTHIC_ENGINEERING.md",
+            self.root / "SYSTEM_VISION.md",
             self.docs_dir / "PHILOSOPHY.md",
             self.docs_dir / "ARCHITECTURE.md",
             self.docs_dir / "DOMAIN_MAP.md",
@@ -194,6 +196,28 @@ class MythicWorkflow:
             5. Build
             6. Verify
             7. Reflect
+            """
+        ).strip() + "\n"
+
+    def _vision_template(self, goal: str) -> str:
+        return textwrap.dedent(
+            f"""
+            # SYSTEM_VISION
+
+            ## Why this system exists
+            {goal}
+
+            ## Core entities
+            - Entity 1:
+            - Entity 2:
+
+            ## Non-goals
+            - Out of scope 1:
+            - Out of scope 2:
+
+            ## Invariants
+            - Invariant 1:
+            - Invariant 2:
             """
         ).strip() + "\n"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ Homepage = "https://github.com/hrabanazviking/Mythic-Engineering"
 
 [project.scripts]
 mythic-vibe = "mythic_vibe_cli.cli:main"
+mythic = "mythic_vibe_cli.cli:main"
 
 [tool.setuptools]
 packages = ["mythic_vibe_cli"]
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from mythic_vibe_cli.cli import main
+
+
+class MythicCliRitualTests(unittest.TestCase):
+    def test_imbue_creates_system_vision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            code = main(["imbue", "--goal", "Build a test system", "--path", tmp])
+            self.assertEqual(code, 0)
+            vision = Path(tmp) / "SYSTEM_VISION.md"
+            self.assertTrue(vision.exists())
+
+    def test_grimoire_add_and_list(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            add_code = main(["grimoire", "add", "my_pkg.plugin:Plugin", "--path", tmp])
+            self.assertEqual(add_code, 0)
+
+            registry = Path(tmp) / "mythic" / "plugins.json"
+            payload = json.loads(registry.read_text(encoding="utf-8"))
+            self.assertIn("my_pkg.plugin:Plugin", payload["plugins"])
+
+            list_code = main(["grimoire", "list", "--path", tmp])
+            self.assertEqual(list_code, 0)
+
+    def test_db_migrate_creates_database(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            code = main(["db", "migrate", "--path", tmp])
+            self.assertEqual(code, 0)
+            self.assertTrue((Path(tmp) / "mythic" / "weave.db").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Align the CLI with the Mythic Engineering design doc by exposing the ritual-style commands used in the design (imbue, evoke, scry, weave, prune, heal, oath, grimoire, config, db). 
- Make project scaffolding more vision-first by creating and validating a `SYSTEM_VISION.md` artifact during init and diagnostics. 
- Provide lightweight local plumbing for plugins, configuration, and a small local DB to seed further features described in the design doc. 

### Description

- Added ritual command surface and arguments to the CLI parser in `mythic_vibe_cli/cli.py` and wired alias routing so `imbue -> init`, `evoke -> codex-pack`, and `scry -> doctor` among others. 
- Implemented concrete handlers for new commands: `cmd_oath`, `cmd_grimoire` (stores `mythic/plugins.json`), `cmd_config` (appends to `mythic/config.toml`), `cmd_db_migrate` (creates `mythic/weave.db` and `rituals` table), `cmd_weave`, `cmd_prune`, and `cmd_heal`. 
- Extended `MythicWorkflow.init_project` and `doctor` in `mythic_vibe_cli/workflow.py` to create and require `SYSTEM_VISION.md` with a `
_vision_template` helper. 
- Added `mythic` console script alias in `pyproject.toml`, updated `README.md` to document ritual aliases, and added unit tests in `tests/test_cli.py` for `imbue`, `grimoire`, and `db migrate`. 

### Testing

- Ran `python -m unittest discover -s tests -v`, which executed 6 tests (including the new `tests/test_cli.py` and existing workflow tests) and all tests passed. 
- Noted that `python -m unittest -v` without test discovery did not find tests in this layout, so the explicit discovery command was used to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95413c054832582a4dd98663f7ee5)