### PR TITLE
Add layered config support and codex packet auto-compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This now supports a **ChatGPT Plus ($20/mo) friendly Codex workflow**:
 - Generate a structured prompt packet from your local project context.
 - Paste it into ChatGPT/Codex.
 - Log the assistant output back into Mythic tracking.
+- Configure packet sizing + auto-compaction with global/local config files.
 
 No API key is required for this copy/paste flow.
 
@@ -61,6 +62,37 @@ Custom destination:
 
 ```bash
 mythic-vibe import-md --target docs/reference/mythic
+```
+
+
+## Configuration (inspired by OpenCode-style layering)
+
+`mythic-vibe` resolves config from these files (low → high precedence):
+- `~/.mythic-vibe.json`
+- `$XDG_CONFIG_HOME/mythic-vibe/config.json`
+- `<project>/.mythic-vibe.json`
+
+Environment variables override file values:
+- `MYTHIC_EXCERPT_LIMIT`
+- `MYTHIC_PACKET_CHAR_BUDGET`
+- `MYTHIC_AUTO_COMPACT`
+
+Inspect the effective config:
+
+```bash
+mythic-vibe config --path .
+```
+
+Example config file:
+
+```json
+{
+  "codex": {
+    "excerpt_limit": 2200,
+    "packet_char_budget": 14000,
+    "auto_compact": true
+  }
+}
 ```
 
 ## ChatGPT Plus / Codex bridge flow

--- a/mythic_vibe_cli/cli.py
+++ b/mythic_vibe_cli/cli.py
@@ -6,6 +6,7 @@ import sys
 
 from . import __version__
 from .codex_bridge import CodexBridge, CodexPacketRequest
+from .config import ConfigStore
 from .mythic_data import MethodStore
 from .workflow import MythicRunConfig, MythicWorkflow, PHASES
 
@@ -65,6 +66,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("sync", help="Sync Mythic Engineering method notes from GitHub")
     sub.add_parser("method", help="Print active Mythic method notes")
+
+
+    config_cmd = sub.add_parser("config", help="Show resolved mythic-vibe configuration")
+    config_cmd.add_argument("--path", default=".", help="Project directory used for local overrides")
 
     doctor = sub.add_parser("doctor", help="Validate Mythic project structure and status")
     doctor.add_argument("--path", default=".", help="Project directory (default: current directory)")
@@ -166,6 +171,26 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_config(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    loaded = ConfigStore(root).load()
+
+    print("Resolved mythic-vibe configuration")
+    print(f"- Project path: {root}")
+    if loaded.sources:
+        print("- Loaded sources (low -> high precedence):")
+        for src in loaded.sources:
+            print(f"  - {src}")
+    else:
+        print("- Loaded sources: none (using defaults + env vars)")
+
+    print("- Effective values:")
+    print(f"  - codex.excerpt_limit: {loaded.config.excerpt_limit}")
+    print(f"  - codex.packet_char_budget: {loaded.config.packet_char_budget}")
+    print(f"  - codex.auto_compact: {str(loaded.config.auto_compact).lower()}")
+    return 0
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     workflow = MythicWorkflow(root)
@@ -234,6 +259,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_sync()
     if args.command == "method":
         return cmd_method()
+    if args.command == "config":
+        return cmd_config(args)
     if args.command == "doctor":
         return cmd_doctor(args)
 

--- a/mythic_vibe_cli/codex_bridge.py
+++ b/mythic_vibe_cli/codex_bridge.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 import textwrap
 
+from .config import AppConfig, ConfigStore
+
 
 @dataclass
 class CodexPacketRequest:
@@ -14,11 +16,12 @@ class CodexPacketRequest:
 
 
 class CodexBridge:
-    def __init__(self, root: Path):
+    def __init__(self, root: Path, config: AppConfig | None = None):
         self.root = root
         self.docs_dir = root / "docs"
         self.tasks_dir = root / "tasks"
         self.mythic_dir = root / "mythic"
+        self.config = config or ConfigStore(root).load().config
 
     def create_packet(self, request: CodexPacketRequest, out_file: Path | None = None) -> Path:
         out = out_file or (self.mythic_dir / "codex_prompt.md")
@@ -31,11 +34,12 @@ class CodexBridge:
             return fallback
         return path.read_text(encoding="utf-8")
 
-    def _safe_excerpt(self, text: str, limit: int = 1800) -> str:
+    def _safe_excerpt(self, text: str, limit: int | None = None) -> str:
+        effective_limit = limit or self.config.excerpt_limit
         compact = text.strip()
-        if len(compact) <= limit:
+        if len(compact) <= effective_limit:
             return compact
-        return compact[:limit] + "\n... [truncated by mythic-vibe]"
+        return compact[:effective_limit] + "\n... [truncated by mythic-vibe]"
 
     def _status_snapshot(self) -> str:
         path = self.mythic_dir / "status.json"
@@ -56,12 +60,36 @@ class CodexBridge:
             indent=2,
         )
 
+    def _compact_sections(self, sections: dict[str, str], budget: int) -> dict[str, str]:
+        total = sum(len(value) for value in sections.values())
+        if total <= budget:
+            return sections
+
+        keys = list(sections.keys())
+        share = max(200, budget // max(1, len(keys)))
+
+        compacted: dict[str, str] = {}
+        for key in keys:
+            compacted[key] = self._safe_excerpt(sections[key], limit=share)
+
+        return compacted
+
     def _render_packet(self, request: CodexPacketRequest) -> str:
-        goals = self._safe_excerpt(self._read_optional(self.tasks_dir / "current_GOALS.md"))
-        architecture = self._safe_excerpt(self._read_optional(self.docs_dir / "ARCHITECTURE.md"))
-        plan = self._safe_excerpt(self._read_optional(self.mythic_dir / "plan.md"))
-        loop = self._safe_excerpt(self._read_optional(self.mythic_dir / "loop.md"))
+        sections = {
+            "goals": self._safe_excerpt(self._read_optional(self.tasks_dir / "current_GOALS.md")),
+            "architecture": self._safe_excerpt(self._read_optional(self.docs_dir / "ARCHITECTURE.md")),
+            "plan": self._safe_excerpt(self._read_optional(self.mythic_dir / "plan.md")),
+            "loop": self._safe_excerpt(self._read_optional(self.mythic_dir / "loop.md")),
+        }
         status = self._status_snapshot()
+
+        if self.config.auto_compact:
+            sections = self._compact_sections(sections, self.config.packet_char_budget)
+
+        goals = sections["goals"]
+        architecture = sections["architecture"]
+        plan = sections["plan"]
+        loop = sections["loop"]
 
         return textwrap.dedent(
             f"""

--- a/mythic_vibe_cli/config.py
+++ b/mythic_vibe_cli/config.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+
+
+@dataclass
+class AppConfig:
+    excerpt_limit: int = 1800
+    packet_char_budget: int = 12000
+    auto_compact: bool = True
+
+
+@dataclass
+class LoadedConfig:
+    config: AppConfig
+    sources: list[Path]
+
+
+class ConfigStore:
+    def __init__(self, project_root: Path | None = None):
+        self.project_root = project_root.resolve() if project_root else None
+
+    def _candidate_paths(self) -> list[Path]:
+        home = Path.home()
+        xdg_home = Path(os.environ.get("XDG_CONFIG_HOME", home / ".config"))
+
+        paths = [
+            home / ".mythic-vibe.json",
+            xdg_home / "mythic-vibe" / "config.json",
+        ]
+        if self.project_root:
+            paths.append(self.project_root / ".mythic-vibe.json")
+        return paths
+
+    def load(self) -> LoadedConfig:
+        payload: dict = {}
+        sources: list[Path] = []
+
+        for path in self._candidate_paths():
+            if not path.exists():
+                continue
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if isinstance(data, dict):
+                payload = _deep_merge(payload, data)
+                sources.append(path)
+
+        codex = payload.get("codex", {}) if isinstance(payload.get("codex", {}), dict) else {}
+
+        config = AppConfig(
+            excerpt_limit=_parse_int_env(
+                "MYTHIC_EXCERPT_LIMIT",
+                codex.get("excerpt_limit", 1800),
+                minimum=200,
+                maximum=12000,
+            ),
+            packet_char_budget=_parse_int_env(
+                "MYTHIC_PACKET_CHAR_BUDGET",
+                codex.get("packet_char_budget", 12000),
+                minimum=1000,
+                maximum=100000,
+            ),
+            auto_compact=_parse_bool_env("MYTHIC_AUTO_COMPACT", codex.get("auto_compact", True)),
+        )
+
+        return LoadedConfig(config=config, sources=sources)
+
+
+def _deep_merge(base: dict, incoming: dict) -> dict:
+    out = dict(base)
+    for key, value in incoming.items():
+        if key in out and isinstance(out[key], dict) and isinstance(value, dict):
+            out[key] = _deep_merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+def _parse_int_env(name: str, fallback: int, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(name)
+    value = fallback
+    if raw is not None:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = fallback
+    return max(minimum, min(maximum, int(value)))
+
+
+def _parse_bool_env(name: str, fallback: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return bool(fallback)
+
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return bool(fallback)

--- a/tests/test_config_and_bridge.py
+++ b/tests/test_config_and_bridge.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from mythic_vibe_cli.codex_bridge import CodexBridge, CodexPacketRequest
+from mythic_vibe_cli.config import ConfigStore
+
+
+class ConfigAndBridgeTests(unittest.TestCase):
+    def test_config_layering_with_project_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            xdg = root / "xdg"
+            project = root / "project"
+            home.mkdir(parents=True, exist_ok=True)
+            xdg.mkdir(parents=True, exist_ok=True)
+            project.mkdir(parents=True, exist_ok=True)
+
+            (home / ".mythic-vibe.json").write_text('{"codex": {"excerpt_limit": 900}}', encoding="utf-8")
+            (xdg / "mythic-vibe" / "config.json").parent.mkdir(parents=True, exist_ok=True)
+            (xdg / "mythic-vibe" / "config.json").write_text(
+                '{"codex": {"packet_char_budget": 7000}}', encoding="utf-8"
+            )
+            (project / ".mythic-vibe.json").write_text(
+                '{"codex": {"excerpt_limit": 1300, "auto_compact": false}}', encoding="utf-8"
+            )
+
+            old_home = os.environ.get("HOME")
+            old_xdg = os.environ.get("XDG_CONFIG_HOME")
+            try:
+                os.environ["HOME"] = str(home)
+                os.environ["XDG_CONFIG_HOME"] = str(xdg)
+                loaded = ConfigStore(project).load()
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+                if old_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = old_xdg
+
+            self.assertEqual(loaded.config.excerpt_limit, 1300)
+            self.assertEqual(loaded.config.packet_char_budget, 7000)
+            self.assertFalse(loaded.config.auto_compact)
+            self.assertEqual(len(loaded.sources), 3)
+
+    def test_codex_bridge_auto_compacts_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir(parents=True, exist_ok=True)
+            (root / "tasks").mkdir(parents=True, exist_ok=True)
+            (root / "mythic").mkdir(parents=True, exist_ok=True)
+
+            long_text = "A" * 5000
+            (root / "tasks" / "current_GOALS.md").write_text(long_text, encoding="utf-8")
+            (root / "docs" / "ARCHITECTURE.md").write_text(long_text, encoding="utf-8")
+            (root / "mythic" / "plan.md").write_text(long_text, encoding="utf-8")
+            (root / "mythic" / "loop.md").write_text(long_text, encoding="utf-8")
+
+            (root / ".mythic-vibe.json").write_text(
+                '{"codex": {"excerpt_limit": 3000, "packet_char_budget": 1200, "auto_compact": true}}',
+                encoding="utf-8",
+            )
+
+            bridge = CodexBridge(root)
+            packet = bridge._render_packet(CodexPacketRequest(task="x", phase="plan", audience="beginner"))
+            self.assertIn("[truncated by mythic-vibe]", packet)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small, predictable layered configuration model (global + XDG + project) so users can control Codex packet sizing without editing code. 
- Prevent oversized prompt packets from blowing past user budgets or model context windows by adding configurable compaction. 
- Expose effective configuration to users so they can inspect precedence and environment overrides easily.

### Description
- Add `mythic_vibe_cli/config.py` implementing `ConfigStore`, `AppConfig`, layered config resolution (`~/.mythic-vibe.json`, `$XDG_CONFIG_HOME/mythic-vibe/config.json`, `<project>/.mythic-vibe.json`) and env var overrides (`MYTHIC_EXCERPT_LIMIT`, `MYTHIC_PACKET_CHAR_BUDGET`, `MYTHIC_AUTO_COMPACT`).
- Wire configuration into `CodexBridge` (constructor accepts `config` or loads it) and use the values to control excerpt sizing via `CodexBridge._safe_excerpt` and to trigger automatic section compaction via a new `_compact_sections` helper when `auto_compact` is enabled.
- Add a new CLI subcommand `mythic-vibe config` (implemented in `mythic_vibe_cli/cli.py`) that prints resolved sources and effective `codex` values.
- Update `README.md` to document the configuration model and example config file, and add tests in `tests/test_config_and_bridge.py` covering config layering and auto-compaction behavior.

### Testing
- Ran `python -m unittest discover -s tests -v` which executed 5 tests and returned `OK`.
- Ran `python -m mythic_vibe_cli.cli config --path .` which printed the resolved configuration and effective values successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e955e61594832594588528d62f5587)