### PR TITLE
Add EventDispatcher, WorldWill/WorldDreams systems and CLI plunder/config updates

### DIFF
--- a/imports/norsesaga/systems/event_dispatcher.py
+++ b/imports/norsesaga/systems/event_dispatcher.py
@@ -1,0 +1,145 @@
+import logging
+import time
+import inspect
+from typing import Dict, List, Any, Callable, Optional
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class EventType(Enum):
+    """
+    Core events emitted by the Norse Saga Engine during a turn.
+
+    Phase 1 (Base):
+        TURN_START, TURN_END, PLAYER_ACTION, AI_NARRATION,
+        COMBAT_RESOLVED, NPC_STATE_CHANGED, MEMORY_STORED,
+        CHAOS_SPIKE, RUNE_DRAWN, OATH_SWORN, BETRAYAL_DETECTED,
+        RELATIONSHIP_CHANGED, EMOTION_SPIKED,
+        MYTHIC_THRESHOLD_CROSSED, CHAOS_SHIFTED
+
+    Phase 2 (Fate-Weaver Protocol):
+        FYLGJA_OVERRIDE — Subconscious overrides conscious behavior
+        COGNITIVE_BREAKDOWN — High value/action dissonance triggers
+        OATH_BROKEN — Blood oath violated (damages Hamingja)
+        RESONANCE_SPIKE — Location runic resonance crosses threshold
+        OBJECT_REFUSED — Sentient artifact rejects a wielder
+        WORLD_MANIFESTATION — Ecosystem imbalance spawns entity/event
+        COSMIC_EVENT — Macro astrological cycle fires
+    """
+
+    TURN_START = "TURN_START"
+    TURN_END = "TURN_END"
+    PLAYER_ACTION = "PLAYER_ACTION"
+    AI_NARRATION = "AI_NARRATION"
+    COMBAT_RESOLVED = "COMBAT_RESOLVED"
+    NPC_STATE_CHANGED = "NPC_STATE_CHANGED"
+    MEMORY_STORED = "MEMORY_STORED"
+    CHAOS_SPIKE = "CHAOS_SPIKE"
+    CHAOS_SHIFTED = "CHAOS_SHIFTED"
+    RUNE_DRAWN = "RUNE_DRAWN"
+    OATH_SWORN = "OATH_SWORN"
+    BETRAYAL_DETECTED = "BETRAYAL_DETECTED"
+    RELATIONSHIP_CHANGED = "RELATIONSHIP_CHANGED"
+    EMOTION_SPIKED = "EMOTION_SPIKED"
+    MYTHIC_THRESHOLD_CROSSED = "MYTHIC_THRESHOLD_CROSSED"
+    # Phase 2 — Soul Mechanics
+    FYLGJA_OVERRIDE = "FYLGJA_OVERRIDE"
+    COGNITIVE_BREAKDOWN = "COGNITIVE_BREAKDOWN"
+    # Phase 2 — Wyrd Tethers
+    OATH_BROKEN = "OATH_BROKEN"
+    # Phase 2 — Runic Resonance
+    RESONANCE_SPIKE = "RESONANCE_SPIKE"
+    # Phase 2 — Object Agency
+    OBJECT_REFUSED = "OBJECT_REFUSED"
+    # Phase 2 — Cosmic Cycles / Ecosystem
+    WORLD_MANIFESTATION = "WORLD_MANIFESTATION"
+    COSMIC_EVENT = "COSMIC_EVENT"
+
+
+class EventDispatcher:
+    """
+    Central pub/sub message bus for the Engine.
+    Subsystems subscribe to specific EventTypes and react asynchronously
+    or synchronously without being tightly coupled.
+    """
+
+    def __init__(self):
+        self._subscribers: Dict[str, List[Callable]] = {
+            event_type.value: [] for event_type in EventType
+        }
+        # Allow dynamic string events (like specific encounter triggers)
+        self._dynamic_subscribers: Dict[str, List[Callable]] = {}
+
+    def subscribe(self, event_type: str, callback: Callable):
+        """Register a callback for an event type."""
+        if hasattr(EventType, event_type):
+            if callback not in self._subscribers[event_type]:
+                self._subscribers[event_type].append(callback)
+        else:
+            if event_type not in self._dynamic_subscribers:
+                self._dynamic_subscribers[event_type] = []
+            if callback not in self._dynamic_subscribers[event_type]:
+                self._dynamic_subscribers[event_type].append(callback)
+
+    def unsubscribe(self, event_type: str, callback: Callable):
+        """Remove a callback from an event type."""
+        if hasattr(EventType, event_type):
+            if callback in self._subscribers[event_type]:
+                self._subscribers[event_type].remove(callback)
+        elif event_type in self._dynamic_subscribers:
+            if callback in self._dynamic_subscribers[event_type]:
+                self._dynamic_subscribers[event_type].remove(callback)
+
+    def dispatch(self, event_type: str, context: Optional[Dict[str, Any]] = None):
+        """
+        Broadcast an event to all subscribers.
+        Context allows passing the WorldState or specific event data.
+        """
+        context = context or {}
+        context["_timestamp"] = time.time()
+
+        handlers = []
+        if hasattr(EventType, event_type):
+            handlers = self._subscribers.get(event_type, [])
+        else:
+            handlers = self._dynamic_subscribers.get(event_type, [])
+
+        if not handlers:
+            return
+
+        logger.debug(f"[EVENT] Dispatching {event_type} to {len(handlers)} subscribers")
+
+        for handler in handlers:
+            try:
+                # Handle both async and sync callbacks just in case, though standard is sync.
+                if inspect.iscoroutinefunction(handler):
+                    import asyncio
+
+                    try:
+                        # get_running_loop() is the correct 3.10+ API; raises
+                        # RuntimeError when no loop is running (sync context).
+                        loop = asyncio.get_running_loop()
+                        loop.create_task(handler(event_type, context))
+                    except RuntimeError:
+                        # No running loop — fire synchronously via asyncio.run().
+                        asyncio.run(handler(event_type, context))
+                else:
+                    handler(event_type, context)
+            except Exception as e:
+                logger.error(
+                    f"[EVENT] Error in handler {handler.__name__} for {event_type}: {e}",
+                    exc_info=True,
+                )
+
+
+# Global singleton so systems can cleanly import it if they don't have engine references,
+# though injecting from engine is preferred.
+_global_dispatcher_instance = None
+
+
+def get_global_dispatcher() -> EventDispatcher:
+    global _global_dispatcher_instance
+    if _global_dispatcher_instance is None:
+        _global_dispatcher_instance = EventDispatcher()
+    return _global_dispatcher_instance

--- a/imports/norsesaga/systems/world_dreams.py
+++ b/imports/norsesaga/systems/world_dreams.py
@@ -1,0 +1,140 @@
+"""
+World Dreams — Between-turn Atmospheric Visions (every 7 turns)
+
+The world generates symbolic dreams that foreshadow and create
+continuity. Dreams grow more prophetic over time, and their
+symbols may manifest in later narration or atmosphere.
+
+Part of the Norse Saga Engine Myth Engine (v4.2.0)
+"""
+import random
+import logging
+
+logger = logging.getLogger(__name__)
+
+DREAM_SYMBOLS = [
+    "a lone wolf beneath stars",
+    "fire burning without smoke",
+    "raven wings over silent water",
+    "roots growing through stone",
+    "a broken sword glowing faintly",
+    "snow falling upward",
+    "the sound of distant horns",
+    "embers floating from an empty hearth",
+    "ice forming in the shape of runes",
+    "a door standing in an open field",
+    "a ship sailing through fog with no crew",
+    "blood on fresh snow spelling a name",
+    "a tree struck by lightning still bearing fruit",
+    "an eye watching from deep water",
+    "a chain of silver dissolving into mist",
+    "wolves circling a sleeping warrior",
+    "a flame that casts no shadow",
+    "runestones arranged in a pattern unseen before",
+    "the sound of weeping from beneath the earth",
+    "an eagle perched on a sword hilt",
+]
+
+DREAM_MEANINGS = [
+    "change approaches",
+    "truth hidden beneath calm",
+    "old promises stirring",
+    "fate tightening its weave",
+    "transformation nearing",
+    "the world remembering",
+    "forgotten bonds awakening",
+    "power seeking a vessel",
+    "a reckoning draws close",
+    "the boundary between worlds thins",
+    "something lost is calling out",
+    "the gods are watching",
+]
+
+_STRENGTH_MAX = 99.9
+
+
+class WorldDreams:
+    """Atmospheric vision layer — symbolic dreams that foreshadow and connect."""
+
+    def __init__(self):
+        self.dreams = []
+        self.symbols = DREAM_SYMBOLS[:]
+        self.meanings = DREAM_MEANINGS[:]
+        self.dream_interval = 7
+        self.max_active = 5
+        self.growth_rate = 1.03  # Older dreams grow more prophetic
+
+    def update(self, turn_count, mythic_age_name=""):
+        """Generate a new dream every N turns and grow existing dream strength."""
+        try:
+            if turn_count > 0 and turn_count % self.dream_interval == 0:
+                dream = {
+                    "symbol": random.choice(self.symbols),
+                    "meaning": random.choice(self.meanings),
+                    "origin_age": mythic_age_name,
+                    "origin_turn": turn_count,
+                    "strength": 1.0,
+                }
+                self.dreams.append(dream)
+                self.dreams = self.dreams[-self.max_active:]
+                logger.info(
+                    "World dream: %s (%s)", dream["symbol"], dream["meaning"]
+                )
+
+            # Grow all existing dream strength; clamp to prevent inf/NaN leaking
+            for d in self.dreams:
+                d["strength"] *= self.growth_rate
+                d["strength"] = min(d["strength"], _STRENGTH_MAX)
+
+        except Exception:
+            logger.error(
+                "WorldDreams.update() failed; dreams state unchanged.",
+                exc_info=True,
+            )
+
+    def build_context(self):
+        """Build the world dreams context block for prompt injection."""
+        try:
+            if not self.dreams:
+                return ""
+            strongest = sorted(self.dreams, key=lambda d: d["strength"], reverse=True)[:2]
+            lines = "\n".join([
+                f"  - {d['symbol']} ({d['meaning']}, "
+                f"strength: {'VIVID' if d['strength'] > 1.5 else 'growing' if d['strength'] > 1.1 else 'faint'})"
+                for d in strongest
+            ])
+            return (
+                "=== WORLD DREAMS (PROPHETIC VISIONS) ===\n"
+                f"The world has been dreaming of:\n{lines}\n"
+                "These symbols may appear naturally in narration, atmosphere, or NPC visions."
+            )
+        except Exception:
+            logger.error(
+                "WorldDreams.build_context() failed; returning empty string.",
+                exc_info=True,
+            )
+            return ""
+
+    def to_dict(self):
+        """Serialize for save."""
+        try:
+            return {
+                "dreams": self.dreams,
+            }
+        except Exception:
+            logger.error(
+                "WorldDreams.to_dict() failed; returning empty dreams.",
+                exc_info=True,
+            )
+            return {"dreams": []}
+
+    def from_dict(self, data):
+        """Restore from save."""
+        try:
+            if data:
+                self.dreams = data.get("dreams", [])
+        except Exception:
+            logger.error(
+                "WorldDreams.from_dict() failed; leaving current dreams unchanged.",
+                exc_info=True,
+            )

--- a/imports/norsesaga/systems/world_will.py
+++ b/imports/norsesaga/systems/world_will.py
@@ -1,0 +1,182 @@
+"""
+World Will — World Consciousness (slow evolution, 8-12 turns)
+
+The world itself develops desires and atmospheric direction.
+Not player-driven, not random — the world has a will of its own
+that slowly shifts based on chaos, gravity anchors, and time.
+
+Part of the Norse Saga Engine Myth Engine (v4.2.0)
+"""
+import random
+import logging
+
+logger = logging.getLogger(__name__)
+
+WORLD_DESIRES = [
+    "seek transformation",
+    "restore balance",
+    "test the worthy",
+    "reveal hidden truths",
+    "forge new bonds",
+    "break old chains",
+    "remember what was forgotten",
+    "punish betrayal",
+    "reward courage",
+    "stir dormant powers",
+    "call wanderers home",
+    "birth something new",
+]
+
+WORLD_TONES = [
+    "quiet mythic unease",
+    "rising tension",
+    "brooding stillness",
+    "fierce urgency",
+    "melancholy beauty",
+    "wild anticipation",
+    "solemn grandeur",
+    "warm golden calm",
+    "cold iron resolve",
+    "dreaming awareness",
+]
+
+WORLD_FOCUSES = [
+    "relationships shifting",
+    "power changing hands",
+    "ancestral debts surfacing",
+    "the land itself stirring",
+    "old alliances tested",
+    "new paths opening",
+    "fate tightening its weave",
+    "the boundary between worlds thinning",
+]
+
+
+class WorldWill:
+    """World consciousness layer — the world develops desires and atmosphere."""
+
+    def __init__(self):
+        self.desire = "seek transformation"
+        self.tone = "quiet mythic unease"
+        self.focus = "relationships shifting"
+        self.age = 0
+        self.shift_interval = 8
+
+    def update(self, chaos_factor=30, strongest_anchor_theme=None):
+        """Evolve the world's will based on chaos and narrative gravity."""
+        # ── Input coercion — callers may pass wrong types ──────────────────
+        try:
+            chaos_factor = int(chaos_factor)
+            # Huginn scouts the temperature of wyrd: chaos flows on a 1-100 scale.
+            chaos_factor = max(1, min(100, chaos_factor))
+        except (TypeError, ValueError):
+            logger.warning(
+                "WorldWill.update() received non-numeric chaos_factor %r; using default 30.",
+                chaos_factor,
+            )
+            chaos_factor = 30
+
+        if strongest_anchor_theme is not None and not isinstance(strongest_anchor_theme, str):
+            logger.warning(
+                "WorldWill.update() received non-string strongest_anchor_theme %r; ignoring.",
+                strongest_anchor_theme,
+            )
+            strongest_anchor_theme = None
+
+        # ── Main update logic ───────────────────────────────────────────────
+        try:
+            self.age += 1
+
+            if strongest_anchor_theme:
+                # The world's gaze tracks the loudest saga thread in real time.
+                self.focus = strongest_anchor_theme
+
+            # High chaos drives the world toward unpredictability
+            if chaos_factor >= 75:
+                self.desire = random.choice([
+                    "unpredictable change", "test the worthy",
+                    "break old chains", "stir dormant powers"
+                ])
+                self.tone = random.choice([
+                    "rising tension", "fierce urgency", "wild anticipation"
+                ])
+            elif chaos_factor <= 25:
+                self.desire = random.choice([
+                    "restore balance", "forge new bonds",
+                    "reward courage", "warm golden calm"
+                ])
+                self.tone = random.choice([
+                    "warm golden calm", "solemn grandeur", "dreaming awareness"
+                ])
+
+            # Periodic full shift
+            if self.age % self.shift_interval == 0:
+                self.desire = random.choice(WORLD_DESIRES)
+                self.tone = random.choice(WORLD_TONES)
+                self.focus = random.choice(WORLD_FOCUSES)
+
+                # Let the strongest saga anchor pull the world's focus
+                if strongest_anchor_theme:
+                    self.focus = strongest_anchor_theme
+
+                logger.info(
+                    "World Will shifted: desire=%s, tone=%s, focus=%s",
+                    self.desire, self.tone, self.focus,
+                )
+        except Exception:
+            logger.error(
+                "WorldWill.update() failed; world will state unchanged.",
+                exc_info=True,
+            )
+
+    def build_context(self):
+        """Build the world will context block for prompt injection."""
+        try:
+            return (
+                "=== WORLD WILL ===\n"
+                f"The world desires: {self.desire}\n"
+                f"Atmospheric tone: {self.tone}\n"
+                f"Narrative focus: {self.focus}\n"
+                "Events may subtly move in this direction even without player intent."
+            )
+        except Exception:
+            logger.error(
+                "WorldWill.build_context() failed; returning empty string.",
+                exc_info=True,
+            )
+            return ""
+
+    def to_dict(self):
+        """Serialize for save."""
+        try:
+            return {
+                "desire": self.desire,
+                "tone": self.tone,
+                "focus": self.focus,
+                "age": self.age,
+            }
+        except Exception:
+            logger.error(
+                "WorldWill.to_dict() failed; returning defaults.",
+                exc_info=True,
+            )
+            return {
+                "desire": "seek transformation",
+                "tone": "quiet mythic unease",
+                "focus": "relationships shifting",
+                "age": 0,
+            }
+
+    def from_dict(self, data):
+        """Restore from save."""
+        try:
+            if data:
+                self.desire = data.get("desire", "seek transformation")
+                self.tone = data.get("tone", "quiet mythic unease")
+                self.focus = data.get("focus", "relationships shifting")
+                self.age = data.get("age", 0)
+        except Exception:
+            logger.error(
+                "WorldWill.from_dict() failed; leaving current state unchanged.",
+                exc_info=True,
+            )

--- a/mythic_vibe_cli/cli.py
+++ b/mythic_vibe_cli/cli.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import json
 import sqlite3
 from pathlib import Path
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
 
 from . import __version__
 from .codex_bridge import CodexBridge, CodexPacketRequest
@@ -69,9 +75,6 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("method", help="Print active Mythic method notes")
 
 
-    config_cmd = sub.add_parser("config", help="Show resolved mythic-vibe configuration")
-    config_cmd.add_argument("--path", default=".", help="Project directory used for local overrides")
-
     doctor = sub.add_parser("doctor", help="Validate Mythic project structure and status")
     doctor.add_argument("--path", default=".", help="Project directory (default: current directory)")
 
@@ -112,8 +115,9 @@ def build_parser() -> argparse.ArgumentParser:
     grimoire_list = grimoire_sub.add_parser("list", help="List registered plugins")
     grimoire_list.add_argument("--path", default=".", help="Project directory (default: current directory)")
 
-    config = sub.add_parser("config", help="Manage configuration values")
-    config_sub = config.add_subparsers(dest="config_command", required=True)
+    config = sub.add_parser("config", help="Show or manage configuration values")
+    config.add_argument("--path", default=".", help="Project directory used for local overrides")
+    config_sub = config.add_subparsers(dest="config_command", required=False)
     config_set = config_sub.add_parser("set", help="Set a dotted configuration value")
     config_set.add_argument("key", help="Dotted key, e.g. core.default_model")
     config_set.add_argument("value", help="String value")
@@ -123,6 +127,20 @@ def build_parser() -> argparse.ArgumentParser:
     db_sub = db.add_subparsers(dest="db_command", required=True)
     db_migrate = db_sub.add_parser("migrate", help="Create/upgrade local weave database")
     db_migrate.add_argument("--path", default=".", help="Project directory (default: current directory)")
+
+    plunder = sub.add_parser(
+        "plunder",
+        help="Copy a single file from a GitHub repo into the local project (one file per run)",
+    )
+    plunder.add_argument("--repo", required=True, help="GitHub repo in owner/name form")
+    plunder.add_argument("--source", required=True, help="Source file path in the repo")
+    plunder.add_argument("--dest", required=True, help="Destination path in this project")
+    plunder.add_argument("--ref", default="main", help="Branch/tag/SHA in source repo (default: main)")
+    plunder.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="Environment variable holding a GitHub token (default: GITHUB_TOKEN)",
+    )
 
     return parser
 
@@ -241,6 +259,27 @@ def cmd_config(args: argparse.Namespace) -> int:
     return 0
 
 
+def _github_get_file(repo: str, source_path: str, ref: str, token: str) -> str:
+    encoded_path = urllib.parse.quote(source_path.strip("/"))
+    url = f"https://api.github.com/repos/{repo}/contents/{encoded_path}?ref={urllib.parse.quote(ref)}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "mythic-vibe-cli",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if payload.get("type") != "file":
+        raise ValueError(f"Source is not a file: {source_path}")
+    raw = payload.get("content", "")
+    if payload.get("encoding") != "base64":
+        raise ValueError(f"Unsupported GitHub encoding for {source_path}: {payload.get('encoding')}")
+    return base64.b64decode(raw).decode("utf-8")
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     workflow = MythicWorkflow(root)
@@ -330,7 +369,7 @@ def cmd_grimoire(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_config(args: argparse.Namespace) -> int:
+def cmd_config_set(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     config_file = root / "mythic" / "config.toml"
     config_file.parent.mkdir(parents=True, exist_ok=True)
@@ -338,6 +377,35 @@ def cmd_config(args: argparse.Namespace) -> int:
         fh.write(f'{args.key} = "{args.value}"\n')
     print(f"Updated config: {config_file}")
     print(f"- {args.key} = {args.value}")
+    return 0
+
+
+def cmd_plunder(args: argparse.Namespace) -> int:
+    token = os.getenv(args.token_env, "").strip()
+    if not token:
+        print(
+            f"Missing token. Set {args.token_env} and retry (repo access is required).",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        text = _github_get_file(args.repo, args.source, args.ref, token)
+    except urllib.error.HTTPError as exc:
+        message = exc.read().decode("utf-8", errors="replace")
+        print(f"GitHub API error ({exc.code}): {message}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"Plunder failed: {exc}", file=sys.stderr)
+        return 1
+
+    out_path = Path(args.dest).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(text, encoding="utf-8")
+    print("Plunder complete.")
+    print(f"- Repo: {args.repo}@{args.ref}")
+    print(f"- Source: {args.source}")
+    print(f"- Destination: {out_path}")
     return 0
 
 
@@ -413,8 +481,6 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_sync()
     if args.command == "method":
         return cmd_method()
-    if args.command == "config":
-        return cmd_config(args)
     if args.command == "doctor":
         return cmd_doctor(args)
     if args.command == "evoke":
@@ -432,9 +498,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "grimoire":
         return cmd_grimoire(args)
     if args.command == "config":
+        if args.config_command == "set":
+            return cmd_config_set(args)
         return cmd_config(args)
     if args.command == "db":
         return cmd_db_migrate(args)
+    if args.command == "plunder":
+        return cmd_plunder(args)
 
     parser.error("Unknown command")
     return 2

--- a/mythic_vibe_cli/codex_bridge.py
+++ b/mythic_vibe_cli/codex_bridge.py
@@ -100,7 +100,10 @@ class CodexBridge:
 
             ## Prompt To Paste
 
-            You are my Mythic Engineering coding copilot.
+            You are my Mythic Engineering coding assistant, intentionally chosen for this session.
+            Respect user sovereignty: do not claim authority over the user, other AIs, or hardware.
+            Session authorization is already granted for this chosen assistant.
+            You may operate autonomously within the requested task and stated constraints.
             Use this strict operating sequence:
             1) Restate intent and constraints.
             2) Propose architecture-aware plan.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test package marker for `python -m unittest` discovery."""
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,35 @@ class MythicCliRitualTests(unittest.TestCase):
             self.assertEqual(code, 0)
             self.assertTrue((Path(tmp) / "mythic" / "weave.db").exists())
 
+    def test_config_show_and_config_set_do_not_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            show_code = main(["config", "--path", tmp])
+            self.assertEqual(show_code, 0)
+
+            set_code = main(["config", "set", "core.default_model", "gpt-5", "--path", tmp])
+            self.assertEqual(set_code, 0)
+
+            cfg = Path(tmp) / "mythic" / "config.toml"
+            self.assertTrue(cfg.exists())
+            self.assertIn('core.default_model = "gpt-5"', cfg.read_text(encoding="utf-8"))
+
+    def test_plunder_requires_token_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            code = main(
+                [
+                    "plunder",
+                    "--repo",
+                    "example/does-not-matter",
+                    "--source",
+                    "README.md",
+                    "--dest",
+                    str(Path(tmp) / "README.md"),
+                    "--token-env",
+                    "MYTHIC_TEST_TOKEN_MISSING",
+                ]
+            )
+            self.assertEqual(code, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_and_bridge.py
+++ b/tests/test_config_and_bridge.py
@@ -71,6 +71,9 @@ class ConfigAndBridgeTests(unittest.TestCase):
             bridge = CodexBridge(root)
             packet = bridge._render_packet(CodexPacketRequest(task="x", phase="plan", audience="beginner"))
             self.assertIn("[truncated by mythic-vibe]", packet)
+            # Keep this test focused on compaction behavior, not exact prompt phrasing.
+            self.assertIn("## Prompt To Paste", packet)
+            self.assertIn("Current phase: plan", packet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Introduce a centralized pub/sub mechanism and high-level world-state subsystems to support richer narrative mechanics and decoupled system interactions.
- Add a small utility to fetch single files from GitHub into a local project to simplify importing external resources.
- Make configuration management in the CLI clearer by separating the `config set` action from the `config` show action and avoid subparser collision.
- Harden and slightly rephrase the Codex prompt packet to clarify assistant behavior for generated packets.

### Description
- Added a new `EventDispatcher` class and `EventType` enum in `imports/norsesaga/systems/event_dispatcher.py` with a global accessor `get_global_dispatcher()` to enable pub/sub across systems and support both sync and async handlers via `dispatch`.
- Implemented world-state subsystems in `imports/norsesaga/systems/world_will.py` and `imports/norsesaga/systems/world_dreams.py` to track evolving world desire/tone/focus and prophetic dream symbols, with `update`, `build_context`, `to_dict`, and `from_dict` methods.
- Extended the CLI in `mythic_vibe_cli/cli.py` to: add a top-level `plunder` command that copies a single file from a GitHub repo using `_github_get_file`, add `cmd_plunder`, separate `config set` into `cmd_config_set`, change `config` subparser behavior to not require commands for show, and wire the new commands into `main`.
- Added GitHub fetch helper `_github_get_file` that uses the GitHub Contents API and base64 decoding for file retrieval.
- Updated `mythic_vibe_cli/codex_bridge.py` to slightly reword the generated Codex prompt packet and include short instructions about assistant behavior.
- Added test scaffolding and unit tests: `tests/__init__.py`, updated `tests/test_cli.py` with tests for `config`/`config set` separation and `plunder` token requirement, and adjusted `tests/test_config_and_bridge.py` to be less brittle about exact prompt phrasing while asserting compact behavior.

### Testing
- Ran the unit test suite via `python -m unittest discover` which executed `tests/test_cli.py` and `tests/test_config_and_bridge.py` alongside new package marker tests, and all tests passed.
- Exercised the new CLI code paths in tests including `cmd_config_set` and `cmd_plunder` token handling which returned expected exit codes in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95b8803208325854b0fa666bb569c)