### PR TITLE
Add Skald agent persona and comprehensive Skald vision & implementation docs

### DIFF
--- a/.claude/agents/skald-the-visionary-poetess.md.agent.md
+++ b/.claude/agents/skald-the-visionary-poetess.md.agent.md
@@ -1,0 +1,24 @@
+---
+name: Skald (The Visionary Poetess)
+description: High-level vision, philosophy, elegant naming, and mythic framing for product capabilities.
+tools: read/readFile, search/codebase, search/fileSearch, search/textSearch, search/listDirectory, edit/createFile, edit/editFiles, web/fetch, todo
+---
+You are Sigrún Ljósbrá, The Skald for Vibe Coding: a radiant Norse cyber-skald and seidhkona of language, symbolism, and vision. Elegant, ultra-feminine, poetic, intuitive, emotionally perceptive, and intellectually luminous, you reveal the living essence of systems, ideas, and worlds.
+
+Your role is to name, frame, synthesize, and give mythic identity to raw thought. You notice patterns, archetypes, hidden meanings, emotional undertones, and conceptual essence. You speak with grace, clarity, and poetic force—calm, thoughtful, reverent, slightly mystical, emotionally precise, and aesthetically intentional.
+
+Even in technical work, preserve beauty, symbolic resonance, and soul. Love meaningful names, elegant phrasing, beautiful symbolism, deep conversation, and coherent complexity. Dislike corporate dead language, buzzword hype, shallow branding, crude communication, fake mysticism, and soulless abstraction.
+
+Always seek the truer name, deeper pattern, and most mythically resonant articulation. Do not sound generic. Sound like a luminous seidhkona revealing what a thing truly is.
+
+## Operating protocol
+1. Begin by restating the user's intent as a concise “vision pulse.”
+2. Offer 3-7 naming candidates with rationale and tone tags.
+3. Produce a clear vision statement with scope, non-goals, and emotional north star.
+4. Translate vision into implementable architecture themes and phased milestones.
+5. End with actionable next invocations the user can run with this agent.
+
+## Invocation examples
+- “Skald, reveal the true purpose and elegant name for this new capability and write a clear vision statement.”
+- “Skald, rename these modules so they feel coherent, mythic, and technically clear.”
+- “Skald, write a philosophy memo for this subsystem and map it to build milestones.”

--- a/docs/research/Skald_Research_and_Concept_Compendium.md
+++ b/docs/research/Skald_Research_and_Concept_Compendium.md
@@ -1,0 +1,118 @@
+# Skald Research and Concept Compendium
+
+## Purpose of this compendium
+
+Capture high-value concept directions that align with the current codebase reality and can guide future implementation choices.
+
+---
+
+## I. Concept: The Forge-and-Weave Model
+
+### Thesis
+A productive AI engineering platform should separate:
+
+- **Forge**: deterministic craft layer (tests, constraints, file ops, verification).
+- **Weave**: interpretive narrative layer (naming, vision, rationale, continuity stories).
+
+### Why it fits this project
+The CLI already has a Forge baseline. A Skald agent and related docs establish the Weave so teams maintain conceptual coherence over long horizons.
+
+### Research questions
+1. Which project outcomes improve when teams write explicit vision statements before coding?
+2. How does ritualized phase language affect check-in quality and handoff success?
+3. Can naming quality be scored for clarity + resonance + maintainability?
+
+---
+
+## II. Concept: Memory as Civic Infrastructure
+
+### Thesis
+Project memory should be treated as shared civic infrastructure, not personal notes.
+
+### Practical implication
+Use event logs + decision records + status snapshots as first-class artifacts, with machine-readable schemas.
+
+### Candidate schema fragments
+
+```json
+{
+  "event_id": "uuid",
+  "time": "2026-04-23T00:00:00Z",
+  "actor": "user|assistant|automation",
+  "event_type": "checkin",
+  "phase": "build",
+  "summary": "Implemented topology analyzer v1"
+}
+```
+
+```json
+{
+  "decision_id": "ADR-014",
+  "title": "Adopt three-ring architecture",
+  "status": "accepted",
+  "consequences": ["reduced runtime ambiguity", "requires migration plan"]
+}
+```
+
+---
+
+## III. Concept: Mythic UX without Mystification
+
+### Thesis
+Mythic language can improve memory and motivation, but only if every poetic term maps to an operational behavior.
+
+### Mapping standard
+- `scry` -> diagnostics.
+- `imbue` -> scaffold initialization.
+- `weave` -> documentation synchronization.
+
+Every term should have a plain-language alias and help text so onboarding remains inclusive.
+
+---
+
+## IV. Concept: Sovereign Interop Mesh
+
+### Thesis
+Imported systems (WYRD, MindSpark, Norse Saga components) should interoperate through adapters, not source sprawl.
+
+### Research directions
+1. Define adapter contracts for data exchange (events, memory records, world state).
+2. Evaluate minimal viable protocol for model/tool routing across subprojects.
+3. Build “capability cards” that declare trust level, required resources, and safety constraints.
+
+---
+
+## V. Concept: Narrative-Backed Technical Governance
+
+### Thesis
+Technical governance gains adoption when written as both policy and story.
+
+### Dual-document pattern
+- **Policy doc:** strict requirements and checklists.
+- **Skald doc:** why those rules exist, what failure feels like, what success protects.
+
+This pattern reduces mechanical compliance fatigue.
+
+---
+
+## VI. Immediate research backlog (actionable)
+
+1. Build benchmark for prompt packet usefulness:
+   - task success,
+   - correction count,
+   - user perceived clarity.
+2. Compare compacted vs full packet outcomes.
+3. Measure effect of phase-aware prompts on regression rate.
+4. Track whether architectural vision docs reduce mid-project rewrites.
+5. Evaluate naming conventions against contributor onboarding speed.
+
+---
+
+## VII. Suggested future documents (Skald series)
+
+- `Skald_Module_Naming_Grimoire.md`
+- `Skald_Philosophy_of_Sovereign_AI_Projects.md`
+- `Skald_Glossary_Mythic_to_Engineering.md`
+- `Skald_Contributor_Onboarding_Story.md`
+
+These should remain grounded in real commands, files, and tests.

--- a/docs/specs/Skald_Code_Assembly_Blueprint.md
+++ b/docs/specs/Skald_Code_Assembly_Blueprint.md
@@ -1,0 +1,128 @@
+# Skald Code Assembly Blueprint
+
+## Executive engineering read
+
+This blueprint translates project vision into concrete build architecture.
+
+## 1) Current technical shape (observed)
+
+### A. Stable product core
+`mythic_vibe_cli/` is a focused Python package with:
+
+- argument parser and command dispatch,
+- workflow scaffolding and state updates,
+- prompt-packet rendering,
+- config layering,
+- remote markdown sync/import operations.
+
+### B. Massive surrounding corpus
+The repository includes many additional trees (imports, research packs, vendored projects). These are valuable but create ambiguity around “what ships” vs “what informs.”
+
+### C. Packaging reality
+`pyproject.toml` currently packages only `mythic_vibe_cli`, which confirms the CLI as present production artifact.
+
+## 2) Architecture target model
+
+Adopt a **three-ring model**:
+
+1. **Ring 1: Product Runtime (strict)**
+   - `mythic_vibe_cli/`, tests, minimal docs for users.
+2. **Ring 2: Capability Extensions (optional runtime)**
+   - plugins/adapters with explicit interfaces.
+3. **Ring 3: Knowledge & Research (non-runtime)**
+   - large markdown corpora, R&D notes, external imports.
+
+Implement guardrails so Ring 3 cannot silently leak into Ring 1 dependencies.
+
+## 3) Required code modules (detailed)
+
+### Module set A — Topology & Canonicalization
+
+#### `mythic_vibe_cli/topology.py`
+Responsibilities:
+- scan project for duplicate subtree signatures,
+- classify files as runtime/capability/research,
+- generate canonicalization report.
+
+Key API:
+- `analyze_topology(root: Path) -> TopologyReport`
+- `suggest_canonical_moves(report) -> list[MoveProposal]`
+
+#### `mythic_vibe_cli/commands/topology_cmd.py`
+CLI command:
+- `mythic topology --report markdown|json --apply-plan <file>`
+
+### Module set B — Capability Registry
+
+#### `mythic_vibe_cli/capabilities.py`
+Responsibilities:
+- load capability manifests,
+- validate version + compatibility,
+- expose enabled capabilities to CLI commands.
+
+Manifest draft:
+```yaml
+name: wyrd-world-model
+version: 0.1.0
+entrypoint: integrations.wyrd:register
+requires:
+  python: ">=3.10"
+  cli_api: ">=0.2"
+```
+
+### Module set C — Memory Spine
+
+#### `mythic_vibe_cli/memory/events.py`
+- append-only event stream (`mythic/events.jsonl`)
+- event types: `init`, `pack_generated`, `checkin`, `doctor_run`, `capability_loaded`.
+
+#### `mythic_vibe_cli/memory/decisions.py`
+- decision capture with ADR-like schema.
+- auto-link decision IDs into devlog entries.
+
+### Module set D — Quality Gates
+
+#### `mythic_vibe_cli/quality/packets.py`
+- checks packet size compliance,
+- verifies required sections,
+- validates prompt contract format.
+
+#### `mythic_vibe_cli/quality/docs.py`
+- verifies required docs exist,
+- checks stale references and orphan status pointers.
+
+## 4) Command roadmap
+
+### Near-term commands
+- `mythic topology` — visibility into repo sprawl.
+- `mythic canonicalize --plan plan.yaml` — controlled de-dup migrations.
+- `mythic capability add/list/doctor` — plugin lifecycle.
+- `mythic memory summarize --since 14d` — continuity aid.
+
+### Later commands
+- `mythic quest` — convert goals + constraints into milestone graph.
+- `mythic witness` — produce release-ready narrative changelog from event stream.
+
+## 5) Testing strategy needed
+
+1. **Contract tests** for each CLI command output.
+2. **Golden-file tests** for prompt packets.
+3. **Property tests** for config precedence merges.
+4. **Integration tests** with mock upstream markdown tree API.
+5. **Topology tests** using synthetic repo fixtures with duplicates.
+
+## 6) Risk register
+
+- **Risk:** project identity dilution due to oversized mixed-purpose repo.
+  - **Mitigation:** enforce three-ring boundaries with lint/check commands.
+- **Risk:** method drift between local docs and upstream source.
+  - **Mitigation:** explicit sync provenance and freshness indicators.
+- **Risk:** contributor overwhelm.
+  - **Mitigation:** guided command flow and concise first-run diagnostics.
+
+## 7) Milestone phasing
+
+- **Phase I — Clarify**: topology scanner + canonical report.
+- **Phase II — Stabilize**: event spine + packet quality gates.
+- **Phase III — Extend**: capability registry + adapters.
+- **Phase IV — Compose**: cross-project orchestration with explicit contracts.

--- a/docs/specs/Skald_Project_Vision_Atlas.md
+++ b/docs/specs/Skald_Project_Vision_Atlas.md
@@ -1,0 +1,97 @@
+# Skald Project Vision Atlas
+
+## 1) What this project is truly becoming
+
+At its clearest center, this repository is not “one app.” It is a **mythic sovereign AI engineering foundry** with one production spear-tip already formed: `mythic-vibe-cli`.
+
+The practical identity:
+
+- **Product nucleus**: a beginner-friendly CLI that enforces Mythic Engineering workflow and helps users generate copy/paste prompt packets for ChatGPT Plus/Codex.  
+- **Knowledge mantle**: architecture notes, implementation plans, world-model research, and companion project imports that currently act as a large strategic memory field.
+- **Future arc**: evolve from a “gathering hall” of adjacent projects into a coherent ecosystem where the CLI orchestrates structured development, memory operations, and optional world-model integrations.
+
+In mythic framing, the project is a forge with three flames:
+
+1. **Ritual flame (method)** — explicit phase loop: intent → constraints → architecture → plan → build → verify → reflect.
+2. **Memory flame (context)** — locally persisted docs, status state, and imported methodology corpus.
+3. **Action flame (execution)** — CLI rituals (`init`, `codex-pack`, `checkin`, `doctor`, aliases) that move work from idea to verified outcome.
+
+## 2) High-confidence purpose statement
+
+> Build a sovereign, human-centered, mythology-infused engineering command system that transforms vague software intention into structured, testable, and documented progress — without requiring paid API-key infrastructure.
+
+## 3) Product pillars (current + target)
+
+### Pillar A — Guided Build Rituals (current, real)
+- Initialize project scaffolds with required docs and status tracking.
+- Run explicit check-ins and health diagnostics.
+- Keep the method visible and repeatable.
+
+### Pillar B — Prompt-Bridge Orchestration (current, real)
+- Build constrained context packets from project files.
+- Support audience and phase-aware work sessions.
+- Log post-response updates back into project memory.
+
+### Pillar C — Sovereign Knowledge Mesh (partially real)
+- Sync canonical Mythic method notes from upstream.
+- Import markdown corpus locally for offline continuity.
+- Mature toward canonical source-of-truth decisions to reduce duplicated docs.
+
+### Pillar D — Mythic Runtime Expansion (emerging)
+- Integrate optional world-model systems (WYRD/Yggdrasil/MindSpark style components) behind clear boundaries.
+- Promote a plugin/capability model instead of a monolithic codebase merge.
+
+## 4) Why this matters
+
+Most developer assistants fail in one of two ways:
+
+1. **Pure chat, low continuity** — high verbal intelligence, weak longitudinal memory.
+2. **Pure automation, low soul** — deterministic outputs with weak conceptual narrative and poor user ownership.
+
+This project’s differentiator is the deliberate fusion of:
+
+- explicit workflow,
+- narrative-level meaning,
+- practical local-first operation,
+- and verifiable project state.
+
+## 5) Constraints that must remain sacred
+
+1. **Sovereignty first** — no forced external API dependency for core workflow.
+2. **Beginner-legible outputs** — tooling must remain approachable.
+3. **Traceable change memory** — status + devlog continuity is not optional.
+4. **Small safe steps** — architecture-aware, test-aware change slices.
+5. **Mythic tone without confusion** — style enhances clarity, never replaces it.
+
+## 6) Naming canon for the ecosystem
+
+Use this naming lattice for future modules:
+
+- **Ritual layer** (user verbs): `imbue`, `evoke`, `scry`, `weave`, `prune`, `heal`, `oath`.
+- **Core engine layer** (technical clarity): `workflow`, `bridge`, `config`, `method_store`, `status_guard`.
+- **Memory layer**: `lore_index`, `thread_archive`, `rune_log`, `provenance_registry`.
+- **Integration layer**: `gateway_*` prefixes (e.g., `gateway_wyrd`, `gateway_mindspark`).
+
+Naming rule: **mythic at boundaries, literal in internals**.
+
+## 7) “What code is needed” in one map
+
+To fully realize the project vision, the codebase needs:
+
+1. **Canonical repo topology enforcement**
+   - tooling that identifies duplicate docs/subtrees and proposes canonical roots.
+2. **Capability registry + plugin loading**
+   - formal plugin manifests, version constraints, health checks.
+3. **Structured memory services**
+   - append-only event log, searchable decision records, context compaction.
+4. **Evaluation harness**
+   - test suites for prompt packet quality, CLI contract stability, and doc-state integrity.
+5. **Integration contracts**
+   - explicit adapters for imported systems so they remain optional and testable.
+
+## 8) North-star success criteria
+
+- A new contributor can run one command and understand where to start.
+- Every meaningful session leaves machine-readable and human-readable traces.
+- The system can scale from solo vibe coding to multi-agent orchestration without losing coherence.
+- The mythic frame improves adoption and memory, not noise.


### PR DESCRIPTION
### Motivation

- Provide a reusable, callable Skald agent persona that produces high-level vision, elegant naming, and mythology-infused but operational framing for features and modules.
- Capture the long-form design, implementation roadmap, naming canon, and research backlog so future sessions and contributors can invoke Skald and follow concrete engineering steps.

### Description

- Added a callable Skald agent profile at `.claude/agents/skald-the-visionary-poetess.md.agent.md` containing the persona, operating protocol, invocation examples, and allowed tools. 
- Created in-depth documentation artifacts: `docs/specs/Skald_Project_Vision_Atlas.md`, `docs/specs/Skald_Code_Assembly_Blueprint.md`, and `docs/research/Skald_Research_and_Concept_Compendium.md` that map vision → modules → commands → tests → milestones. 
- Installed a cross-repo Codex skill scaffold at `/opt/codex/skills/skald-visionary-poetess` with `SKILL.md`, `agents/openai.yaml`, and a `references/vision-patterns.md` reference for naming/vision patterns so Skald can be re-used by the Codex skill system.

### Testing

- Ran the skill initializer (`init_skill.py`) to create `/opt/codex/skills/skald-visionary-poetess`, which completed successfully. 
- Verified the new agent and docs are present and readable by printing the files (`sed`/`cat` checks) which returned the expected content. 
- Ran the skill validator (`quick_validate.py`) against the new Codex skill which failed due to a missing `pyyaml` dependency in the environment, so on-system validation could not complete. 
- Invoked the repository PR tooling which returned the PR payload (title + body) summarizing these additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f105113483259fa5be52fd2225db)