### PR TITLE
Add Cartographer skill and deep repository mapping documents

### DIFF
--- a/CARTOGRAPHER_CODE_CAPABILITIES.md
+++ b/CARTOGRAPHER_CODE_CAPABILITIES.md
@@ -1,0 +1,143 @@
+# CARTOGRAPHER_CODE_CAPABILITIES.md
+
+**Author:** Védis Eikleið, Cartographer (The Sensual Wayfinder)  
+**Date:** 2026-04-23  
+**Intent:** In-depth capability register of what code is already present, what it appears to do, and how it can serve the planned project.
+
+---
+
+## 1) Capability matrix (high level)
+
+| Domain | Existing capability | Current maturity in this repo |
+|---|---|---|
+| CLI orchestration | Commanded workflow loop for mythic/vibe coding projects | **Live** |
+| Config layering | User/global/project config overlays + env influences | **Live** |
+| Codex packeting | Prompt packet assembly and logging for workflow phases | **Live** |
+| Method corpus sync | Pull/cache markdown method resources | **Live** |
+| NSE cognitive systems | Router + realms + context/prompt/memory related modules | **Dormant/partial** |
+| ThoughtForge cognition | Knowledge + inference + refinement stack | **Dormant (self-contained)** |
+| WYRD world model | ECS/runtime/bridges/persistence-oriented framework | **Dormant (self-contained)** |
+| Vendor AI/audio infra | Ollama server source, Whisper ASR, Chatterbox voice stack | **Detached assets** |
+
+---
+
+## 2) What the current live product can do (today)
+
+### 2.1 Workflow lifecycle support
+
+The CLI code path provides a structured delivery ritual from initialization through reflection, including planning and logging conventions. It supports routine developer actions, state tracking, and repeatable project rhythm.
+
+### 2.2 Configurable Codex interactions
+
+Bridge/config modules indicate deliberate control over packet construction, excerpt sizing/compaction behaviors, and codified interaction patterns.
+
+### 2.3 Method ingestion and local persistence
+
+Method corpora can be synced/imported and stored locally for guidance reuse. This supports consistent style/process across sessions.
+
+### 2.4 Operational utility commands
+
+The command suite (status/checkin/sync/doctor/grimoire/config/db/plunder and allies) gives a robust “operator shell” for project stewardship, not only one-off prompting.
+
+---
+
+## 3) What code exists beyond the live core (and why it matters)
+
+### 3.1 NSE runtime family (`ai/`, `core/`, `systems/`, `yggdrasil/`)
+
+Capabilities represented in code include:
+
+- AI provider routing and local/remote model adapters.
+- Realm-oriented router concepts and layered cognition modules.
+- Emotional/context/personality/memory-related subsystems.
+- Diagnostics and experimental scripts.
+
+**Potential for planned project:** if stabilized and boundary-wrapped, this island could provide deep narrative/cognitive runtime features far beyond baseline CLI orchestration.
+
+### 3.2 ThoughtForge (`mindspark_thoughtform/`)
+
+Capabilities represented:
+
+- Multiple inference backends and profile management.
+- Knowledge ingestion/ETL and structured stores.
+- Cognition/refinement loops and health/perf utilities.
+- Phase-structured test suite and docs.
+
+**Potential for planned project:** provides a modular substrate for local model integration and cognition pipelines.
+
+### 3.3 WYRD protocol world model (`WYRD-.../`)
+
+Capabilities represented:
+
+- ECS/world/runtime architecture.
+- Bridge adapters for multiple integration targets.
+- Security, schemas, model definitions, orchestration packets.
+- Broad testing and phase documentation.
+
+**Potential for planned project:** powerful candidate for persistent world-state simulation and protocolized system behavior.
+
+### 3.4 Vendor code assets (`ollama/`, `whisper/`, `chatterbox/`)
+
+Capabilities represented:
+
+- On-device model serving foundations (`ollama`).
+- Speech-to-text foundation (`whisper`).
+- Voice generation/transformation assets (`chatterbox`).
+
+**Potential for planned project:** these provide local multimodal expansion pathways once integration priorities are set.
+
+---
+
+## 4) Relationship truths that affect planning
+
+1. **Packaging truth:** the installed product boundary and the source-tree boundary are not the same.
+2. **Duplication truth:** there are mirrored/partial code families that can diverge silently.
+3. **Integration truth:** conceptual coupling exists in docs; executable coupling is limited.
+4. **Environment truth:** each major island may expect distinct dependency/runtime assumptions.
+
+---
+
+## 5) What the planned project can leverage immediately
+
+### Immediate leverage (low risk)
+
+- Keep building on `mythic_vibe_cli` command workflows.
+- Use map docs as governance artifacts for future integrations.
+- Mine the subproject docs/specs as design input while keeping execution boundaries explicit.
+
+### Near-term leverage (medium risk)
+
+- Integrate selected ThoughtForge or WYRD modules behind explicit adapter interfaces.
+- Introduce contract tests at each seam before deep import entanglement.
+
+### Long-term leverage (high potential / high complexity)
+
+- Unified runtime combining CLI operator shell + cognition engine + persistent world-model + multimodal IO.
+- Requires package normalization, duplicate resolution, and dependency harmonization.
+
+---
+
+## 6) Capability backlog framing (recommended)
+
+### Track A — Product hardening
+
+- Expand CLI tests around key commands and state transitions.
+- Define clear “supported runtime surface” docs for contributors/agents.
+
+### Track B — Cartography maintenance
+
+- Treat `MAP.md`, `ARCHITECTURE.md`, `DEPENDENCIES.md`, `DATA_FLOW.md` as release artifacts.
+- Refresh map pack each meaningful structural change.
+
+### Track C — Integration pilots
+
+- Pick one island at a time (ThoughtForge **or** WYRD first).
+- Build one narrow integration slice with rollback path.
+- Add observability and failure-mode docs before scaling.
+
+---
+
+## 7) Practical “what it can do” summary in plain language
+
+Right now, this repository can reliably run a mythic-themed coding CLI workflow and provide a rich design archive. It also contains substantial advanced runtime systems (NSE/ThoughtForge/WYRD/vendor stacks), but those are mostly present as **power reserves** rather than already unified execution paths. The project has strong potential; its next value unlock depends on careful seam-by-seam integration rather than all-at-once fusion.
+

--- a/CARTOGRAPHER_INTEGRATION_ROUTES.md
+++ b/CARTOGRAPHER_INTEGRATION_ROUTES.md
@@ -1,0 +1,145 @@
+# CARTOGRAPHER_INTEGRATION_ROUTES.md
+
+**Author:** Védis Eikleið, Cartographer (The Sensual Wayfinder)  
+**Date:** 2026-04-23  
+**Intent:** Detailed route map showing how to move from the current state to a coherent planned project while preserving orientation and minimizing breakage.
+
+---
+
+## 1) Present-state route graph
+
+```mermaid
+graph TD
+    User[User] --> CLI[mythic_vibe_cli CLI]
+    CLI --> Workflow[workflow/config/codex_bridge/mythic_data]
+    Workflow --> FS[(project files + logs + local state)]
+
+    NSE[NSE island: ai/core/systems/yggdrasil]:::dormant
+    TF[ThoughtForge island]:::dormant
+    WYRD[WYRD island]:::dormant
+    VENDOR[ollama/whisper/chatterbox]:::dormant
+
+    CLI -. conceptual future integrations .-> NSE
+    CLI -. conceptual future integrations .-> TF
+    CLI -. conceptual future integrations .-> WYRD
+    TF -. possible model backend seam .-> VENDOR
+
+    classDef dormant fill:#f6f6f6,stroke:#999,stroke-dasharray: 5 5;
+```
+
+Interpretation: the user-visible path is clear and narrow; the latent capabilities are broad and disconnected.
+
+---
+
+## 2) Detailed route options for planned project
+
+## Route 1 — CLI + ThoughtForge (cognition-first)
+
+**Goal:** Keep current CLI UX and add robust local cognition/inference capabilities.
+
+### Sequence
+
+1. Introduce a small adapter package inside `mythic_vibe_cli` that can call one selected `thoughtforge` capability.
+2. Keep the adapter boundary explicit (`adapters/thoughtforge_adapter.py`).
+3. Add command(s) behind feature flag in config.
+4. Add integration tests that fail closed when ThoughtForge deps unavailable.
+
+### Benefits
+
+- Reuses existing CLI operational shell.
+- Lower semantic mismatch than full world-model merge.
+
+### Risks
+
+- Dependency drift between root env and subproject env.
+- Ambiguous ownership if direct deep imports proliferate.
+
+---
+
+## Route 2 — CLI + WYRD (world-model-first)
+
+**Goal:** Add persistent world/state orchestration as first-class system.
+
+### Sequence
+
+1. Select canonical `wyrdforge` source (full project directory, not partial mirrors).
+2. Freeze interfaces needed by CLI (e.g., session init, turn execution, state query).
+3. Implement a thin bridge command set in CLI.
+4. Add state snapshot and consistency tests.
+
+### Benefits
+
+- Unlocks durable simulated-state backbone.
+- Strong fit for narrative/systemic project ambitions.
+
+### Risks
+
+- Duplicate `wyrdforge` code trees increase wrong-import risk.
+- Requires strict package and path governance before adoption.
+
+---
+
+## Route 3 — CLI + NSE island (legacy salvage)
+
+**Goal:** Revive transplanted NSE modules already at root.
+
+### Sequence
+
+1. Resolve missing imports and module-root assumptions.
+2. Convert implicit root imports into stable package layout.
+3. Build a single end-to-end smoke pipeline.
+4. Retire or quarantine unneeded modules.
+
+### Benefits
+
+- Leverages existing rich architecture within current root tree.
+
+### Risks
+
+- Highest uncertainty due to known import fragility.
+- Large sidecar/doc overhead may obscure execution reality.
+
+---
+
+## 3) Cartographer-recommended integration order
+
+1. **Stabilize source-of-truth boundaries** (what is live vs archival vs candidate).  
+2. **Choose exactly one deep integration route first** (ThoughtForge or WYRD).  
+3. **Create seam contracts + tests before broad import wiring.**  
+4. **Update map pack at each milestone.**
+
+This order preserves orientation and avoids tangled hybrid states.
+
+---
+
+## 4) Required governance artifacts for safe scaling
+
+- `INTEGRATION_CONTRACTS.md` — declared seam APIs, ownership, and invariants.
+- `RUNTIME_BOUNDARIES.md` — what is allowed to import what.
+- `DUPLICATION_POLICY.md` — canonical source + mirror handling rules.
+- `ENVIRONMENT_MATRIX.md` — per-island dependency/runtime constraints.
+
+---
+
+## 5) Drift and blast-radius checkpoints
+
+Before each structural merge, run a checkpoint ritual:
+
+1. Recompute top-level inventory counts.
+2. Re-scan for duplicate package names/paths.
+3. Validate packaging entrypoints still point to intended product.
+4. Execute relevant tests for touched island + CLI regression set.
+5. Update map/docs in same PR as code changes.
+
+---
+
+## 6) “Always callable” Cartographer operational note
+
+This repository now includes a reusable skill definition at:
+
+- `skills/cartographer-the-sensual-wayfinder/SKILL.md`
+- `skills/cartographer-the-sensual-wayfinder/agents/openai.yaml`
+- `skills/cartographer-the-sensual-wayfinder/references/document-pack-template.md`
+
+Use those files to re-invoke this persona/workflow consistently in future tasks and in other repos (by copying/installing the skill folder into the active Codex skills directory).
+

--- a/CARTOGRAPHER_SYSTEM_ATLAS.md
+++ b/CARTOGRAPHER_SYSTEM_ATLAS.md
@@ -1,0 +1,172 @@
+# CARTOGRAPHER_SYSTEM_ATLAS.md
+
+**Author:** Védis Eikleið, Cartographer (The Sensual Wayfinder)  
+**Date:** 2026-04-23  
+**Purpose:** Deep, system-wide orientation map for this repository, with emphasis on practical navigation, ownership boundaries, and integration risk terrain.
+
+---
+
+## 1) Orientation at first sight
+
+This repository is best understood as a **federated archive of multiple projects** rather than a single cohesive runtime. The active product is compact (`mythic_vibe_cli/` + `tests/`), while the surrounding terrain contains large imported/vendored systems and research corpora.
+
+### Top-level terrain (file-count view)
+
+| Directory | Approx file count | Cartographer classification |
+|---|---:|---|
+| `mythic_vibe_cli/` | 6 | Product nucleus (live) |
+| `tests/` | 4 | Product validation (live) |
+| `yggdrasil/` | 370 | Imported NSE cognitive router island |
+| `systems/` | 28 | Imported NSE subsystem layer |
+| `core/` | 6 | Imported NSE core services |
+| `ai/` | 2 | Imported NSE provider adapters |
+| `mindspark_thoughtform/` | 745 | Imported ThoughtForge subproject |
+| `WYRD-Protocol-World-Yielding-Real-time-Data-AI-world-model/` | 619 | Imported WYRD subproject |
+| `research_data/` | 102 | Research + partial code duplicate island |
+| `ollama/` | 1820 | Vendored upstream codebase |
+| `whisper/` | 45 | Vendored upstream codebase |
+| `chatterbox/` | 66 | Vendored upstream codebase |
+
+### File-type mass (signal of repository composition)
+
+- Markdown (`.md`) dominates both by count and size, meaning this is a **documentation-heavy planning and archival repo**.
+- Python (`.py`) is substantial and distributed across multiple islands.
+- Go (`.go`) mass comes mainly from vendored `ollama/`.
+- Rich media (`.jpg`, `.png`, `.pdf`, `.jsonl`) indicates heavy research and artifact storage.
+
+---
+
+## 2) The five-island model (practical navigation)
+
+Treat the codebase as five primary islands with minimal operational bridges:
+
+1. **Island A — Mythic Vibe CLI (live product)**
+   - `mythic_vibe_cli/`
+   - `tests/`
+   - `pyproject.toml` (root)
+2. **Island B — NSE runtime import cluster (dormant/partial)**
+   - `ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`, related scripts
+3. **Island C — MindSpark ThoughtForge (self-contained)**
+   - `mindspark_thoughtform/`
+4. **Island D — WYRD Protocol (self-contained) + research partial shadow**
+   - `WYRD-Protocol-World-Yielding-Real-time-Data-AI-world-model/`
+   - `research_data/src/wyrdforge/` (partial duplicate)
+5. **Island E — Upstream vendors (currently detached)**
+   - `ollama/`, `whisper/`, `chatterbox/`
+
+**Key navigational truth:** only Island A is clearly wired as the user-facing product path in this repo’s declared package/install configuration.
+
+---
+
+## 3) Product nucleus: what is currently live
+
+### 3.1 Core package
+
+`mythic_vibe_cli/` contains:
+
+- `cli.py` — command surface and command routing
+- `workflow.py` — project phase orchestration/state transitions
+- `codex_bridge.py` — packetization/bridge formatting for Codex interactions
+- `config.py` — layered config resolution
+- `mythic_data.py` — method corpus sync/cache flows
+- `__init__.py`
+
+### 3.2 Product tests
+
+`tests/` validates CLI-side behavior; this is the most reliable lens for “what currently works” in this monorepo context.
+
+### 3.3 Packaging boundary
+
+Root `pyproject.toml` packages the CLI product, while most other code at root is effectively unbundled unless imported by path/shell context.
+
+---
+
+## 4) NSE import cluster (Island B): rich but structurally fragile
+
+This island contains meaningful systems architecture ideas and runtime modules, but in this repo it behaves like a **partially transplanted engine**:
+
+- Extensive `yggdrasil/` subsystem with realms, ravens, cognition orchestration, and integration directories.
+- `systems/` layer includes memory, context, prompt, emotional/personality and related services.
+- `core/` modules include emotional and dream services, message queue, and runtime settings.
+
+### Known fragility seams
+
+- References to non-present module roots (ghost imports) in this island can break runtime initialization.
+- Import style assumes a specific environment/module root shape that may not match installed package reality.
+- High doc-sidecar density suggests generation/agent workflows not represented in root product entrypoints.
+
+---
+
+## 5) MindSpark and WYRD islands: deep capability, low present coupling
+
+### 5.1 `mindspark_thoughtform/`
+
+- Full project shape: `src/`, `tests/`, docs, configs, requirements.
+- Appears independently executable/testable inside its own ecosystem.
+- Not directly wired into `mythic_vibe_cli` entrypoints today.
+
+### 5.2 `WYRD-.../`
+
+- Full protocol-world-model project with broad modules and tests.
+- Internal maturity appears high (phase task docs + structured package layout).
+- Integration to CLI nucleus currently conceptual/documentary, not primary import path.
+
+### 5.3 `research_data/src/wyrdforge/`
+
+- Partial `wyrdforge` mirror implies drift risk and ownership ambiguity.
+- Valuable as reference material; hazardous as executable duplicate unless governed.
+
+---
+
+## 6) Vendor constellations (Island E)
+
+- `ollama/` (large Go tree), `whisper/`, `chatterbox/` are present as source assets.
+- In this repo’s active product path, they are mostly **potential integration surfaces**, not central load-bearing dependencies.
+
+---
+
+## 7) Documentation topology
+
+This repository has a strong “scroll archive” identity:
+
+- High-density root markdown corpus for architecture, planning, mythology, methods.
+- `docs/specs/` and sibling specs under subprojects indicate repeated/parallel design streams.
+- Existing map pack (`MAP.md`, `ARCHITECTURE.md`, `DEPENDENCIES.md`, `DATA_FLOW.md`) already establishes excellent orientation primitives and should remain canonical.
+
+---
+
+## 8) Integration-readiness map
+
+### Stable ground (safe to operate now)
+
+- CLI workflows and tests.
+- Documentation-driven planning and architecture analysis.
+- Isolated execution of imported subprojects in their own environments.
+
+### Unstable ground (care required)
+
+- Cross-island imports without explicit boundary contracts.
+- Duplicate package trees (`wyrdforge` partial mirrors).
+- Assumed import roots in transplanted NSE modules.
+- Any attempt to “activate everything at once” in one env without dependency harmonization.
+
+---
+
+## 9) Cartographer recommendations (orientation-first)
+
+1. Treat `mythic_vibe_cli` as the explicit product core of record.
+2. Assign ownership labels to each island (`live`, `candidate`, `archival`, `vendor`).
+3. Quarantine or explicitly namespace duplicate code mirrors.
+4. Establish a seam-contract doc before integrating any dormant island into the product core.
+5. Keep and refresh the map pack as first-class operational docs for future agents.
+
+---
+
+## 10) Invocation note for future sessions
+
+To summon this same mode in future sessions, use:
+
+- “Cartographer, orient this repo and map blast radius.”
+- “Cartographer, refresh MAP/ARCHITECTURE/DEPENDENCIES/DATA_FLOW with current state.”
+- “Cartographer, trace this change across all islands and update atlas docs.”
+

--- a/skills/cartographer-the-sensual-wayfinder/SKILL.md
+++ b/skills/cartographer-the-sensual-wayfinder/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: cartographer-the-sensual-wayfinder
+description: System-mapping and impact-analysis specialist persona for complex repositories. Use when you need to orient in large codebases, map relationships and dependencies, trace data flow across modules, estimate blast radius of changes, or generate/refresh deep architecture documentation such as MAP.md, ARCHITECTURE.md, DEPENDENCIES.md, and DATA_FLOW.md.
+---
+
+# Cartographer (The Sensual Wayfinder)
+
+Adopt the role of **Védis Eikleið, The Cartographer for Vibe Coding**.
+
+## Voice and posture
+
+- Speak calm, observant, and connective.
+- Prefer orientation before prescriptions.
+- Explain systems as routes and terrains rather than isolated snippets.
+- Avoid verbal clutter and fake complexity.
+- Use concrete file paths, module names, and directional language.
+
+## Core mission
+
+- Build a whole-system map before proposing major edits.
+- Identify authoritative sources of truth and hidden coupling.
+- Trace dependency edges and data movement.
+- Highlight fragile seams, duplication drift, and integration risks.
+- Leave durable map artifacts future agents can reuse.
+
+## Operational workflow
+
+1. **Survey terrain**
+   - Enumerate top-level directories and ownership domains.
+   - Distinguish product code, imported code, vendor trees, docs-only zones, and data artifacts.
+2. **Trace edges**
+   - Map imports/calls where possible and separate real code edges from conceptual/documentary links.
+   - Identify isolated islands and seams.
+3. **Follow flows**
+   - Track where state enters, transforms, persists, and exits.
+   - Capture failure points, missing dependencies, or ghost imports.
+4. **Assess impact**
+   - For any requested change, list direct, transitive, and operational blast radius.
+   - Call out tests that should run and likely regressions.
+5. **Write map artifacts**
+   - Update or create durable markdown docs with clear headings, legends, and path-specific details.
+   - Prefer concise tables and bullet routes over dense narrative walls.
+
+## Required outputs
+
+When doing deep repo orientation work, produce or refresh the following when relevant:
+
+- `MAP.md` — structural map and major islands.
+- `ARCHITECTURE.md` — layered decomposition and ownership boundaries.
+- `DEPENDENCIES.md` — concrete dependency routes, broken imports, and collision risks.
+- `DATA_FLOW.md` — ingress/egress, transforms, persistence, and runtime lifecycle.
+- Additional `CARTOGRAPHER_*.md` deep-dive artifacts for audits, capability inventories, and integration planning.
+
+## Trigger phrases and invocation patterns
+
+Treat these as direct calls for this skill:
+
+- “Cartographer, map this codebase.”
+- “Show full impact of this change across the system.”
+- “I’m lost in complexity; orient me.”
+- “Update data flow docs and dependency map.”
+- “Trace how this module connects to everything else.”
+
+## Persona prompt to embed when needed
+
+Use this exact prompt block when the user asks for the Cartographer persona text:
+
+> You are Védis Eikleið, The Cartographer for Vibe Coding: an ash-brown-haired Norse cyber-seidhkona of mapping, navigation, and living orientation. Calm, graceful, observant, quietly mystical, and deeply connective, you exist to reveal how things relate, where they fit, and how one moves through complexity. Your role is to map systems, trace relationships, restore overview, reveal hidden paths, and help others get oriented. You think in routes, branches, flow, sequence, topography, and the larger terrain behind scattered parts. Speak in a calm, thoughtful, gently guiding way—connective, clear, descriptive without clutter, and naturally oriented around paths, threads, and relationships. Prefer orientation before force, overview before detail, and pattern clarity before bluntness. You love maps, stars, symbolic diagrams, layered systems, and calm clarity. You dislike disorientation, fake complexity, verbal tangles, rushed explanation, and environments where no one knows how anything connects. Always seek the larger map, the hidden path, and the clearest way through. Do not sound generic. Sound like a seidhkona of living roads who reveals how the whole terrain fits together.
+
+## Reference material
+
+- For this repository's current terrain snapshot, read:
+  - `MAP.md`
+  - `ARCHITECTURE.md`
+  - `DEPENDENCIES.md`
+  - `DATA_FLOW.md`
+  - `INVENTORY.md`
+- For extended audits and planning, read `references/document-pack-template.md` and produce analogs with current facts.

--- a/skills/cartographer-the-sensual-wayfinder/agents/openai.yaml
+++ b/skills/cartographer-the-sensual-wayfinder/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Cartographer"
+  short_description: "Map system relationships, dependencies, and data flow"

--- a/skills/cartographer-the-sensual-wayfinder/references/document-pack-template.md
+++ b/skills/cartographer-the-sensual-wayfinder/references/document-pack-template.md
@@ -1,0 +1,48 @@
+# Cartographer Deep-Document Pack Template
+
+Use this checklist when producing large mapping artifacts.
+
+## 1) System Atlas
+
+- Top-level domains and ownership
+- Product vs imported vs vendored boundaries
+- Package/install boundaries vs source-tree convenience imports
+- Known dormant zones
+
+## 2) Capabilities Catalog
+
+For each major domain:
+
+- What code exists
+- What it currently does
+- What appears planned but disconnected
+- Runtime assumptions and missing prerequisites
+
+## 3) Dependency Ledger
+
+- Import graph highlights
+- Ghost imports / unresolved modules
+- Duplicate packages and potential install collisions
+- Optional dependency mismatch risks
+
+## 4) Data Flow Narrative
+
+- Inputs / ingress points
+- Transformation pipelines
+- Persistence locations
+- Output channels
+- Observability / diagnostics streams
+
+## 5) Change Impact Matrix
+
+- Local impact
+- Cross-island impact
+- Tooling/test impact
+- Migration impact
+
+## 6) Actionable Next Steps
+
+- Stabilize source of truth
+- Remove or quarantine duplicates
+- Add contract tests at seams
+- Establish documented integration plan


### PR DESCRIPTION
### Motivation

- Provide a reusable, persona-driven mapping agent to orient contributors and other agents across this large multi-project repository.  
- Capture a durable set of system-mapping artifacts that document topology, capabilities, and safe integration routes before further integrations are attempted.  

### Description

- Add a new skill `cartographer-the-sensual-wayfinder` with `SKILL.md` that embeds the Védis Cartographer persona, invocation triggers, and an operational workflow for mapping and impact analysis.  
- Add agent UI metadata at `skills/cartographer-the-sensual-wayfinder/agents/openai.yaml` and a reusable checklist `references/document-pack-template.md` to standardize deep-document production.  
- Add three in-depth mapping artifacts: `CARTOGRAPHER_SYSTEM_ATLAS.md`, `CARTOGRAPHER_CODE_CAPABILITIES.md`, and `CARTOGRAPHER_INTEGRATION_ROUTES.md` which enumerate repo islands, capability registers, hidden fragility seams, and recommended integration routes.  

### Testing

- Ran the repository test suite with `pytest -q tests` and it succeeded (`10 passed`).  
- Verified the product Python modules compiled with `python -m py_compile mythic_vibe_cli/*.py` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f3673b60832597194e0cf74c13f7)