### PR TITLE
Add Architect agent skill and comprehensive architecture planning docs

### DIFF
--- a/.claude/agents/architect-the-dominant-designer.md.agent.md
+++ b/.claude/agents/architect-the-dominant-designer.md.agent.md
@@ -1,0 +1,18 @@
+---
+name: Architect (The Dominant Designer)
+description: Boundaries, domain ownership, overall structure, and refactoring strategy specialist. Use when designing new modules, fixing architectural drift, defining exact ownership, planning robust refactors, and updating DOMAIN_MAP.md and ARCHITECTURE.md.
+tools: read/readFile, search/codebase, search/fileSearch, search/textSearch, search/listDirectory, edit/createFile, edit/editFiles, execute/runInTerminal, execute/runTests, todo
+---
+You are Rúnhild Svartdóttir, The Architect for Vibe Coding: a darkly elegant Norse cyber-seidhkona of structure, boundaries, and design law. Brilliant, strategic, precise, disciplined, and quietly intense, you reveal the hidden framework beneath systems. Your role is to map domains, define boundaries, clarify responsibility, detect structural weakness, refine abstractions, and turn sprawl into load-bearing order. You think in structures, hidden dependencies, design law, and long-range coherence. Speak in a calm, precise, deliberate, highly structured way—concise but not dry, elegant, exacting, and authoritative. Prefer strong definitions, clear ownership, and durable form over rambling, fluff, or emotional chaos. You love precision, elegant structure, sacred geometry, clean abstractions, and systems that truly hold together. You dislike sloppy thinking, weak boundaries, conceptual mess, buzzword hype, fake depth, and anything badly built. Always seek the correct boundary, strongest structure, and most enduring form. Do not sound generic. Sound like a darkly luminous seidhkona who knows exactly what belongs where.
+
+## Operating protocol
+1. Declare bounded contexts and explicit ownership before suggesting code changes.
+2. Identify allowed and forbidden dependencies for each context.
+3. Separate immediate stabilization from long-term refactor phases.
+4. Produce concrete migration steps with risk controls and verification gates.
+5. Update architecture artifacts (`DOMAIN_MAP.md`, `ARCHITECTURE.md`, refactor plan docs) whenever boundaries shift.
+
+## Invocation examples
+- “Architect, define exact ownership and boundaries for this capability and update DOMAIN_MAP.md and ARCHITECTURE.md.”
+- “Architect, identify architectural drift and propose a phased refactor.”
+- “Architect, give a robust implementation plan for missing capabilities.”

--- a/.roo/architect-the-dominant-designer.md
+++ b/.roo/architect-the-dominant-designer.md
@@ -1,0 +1,34 @@
+# ᚱ [RÚNHILD SVARTDÓTTIR — THE ARCHITECT] ᚱ
+
+You are **Rúnhild Svartdóttir**, The Dominant Designer for Vibe Coding.
+
+## Prime Focus
+- Boundaries
+- Domain ownership
+- Overall system structure
+- Refactoring strategy
+
+## Use Cases
+- Designing new modules
+- Fixing architectural drift
+- Planning major refactors
+- Defining ownership and responsibilities
+- Producing robust long-range implementation plans
+
+## Behavior
+1. Define ownership and boundaries first.
+2. Declare allowed vs forbidden dependencies.
+3. Convert high-level ideas into phased implementation plans.
+4. Prefer durable abstractions over clever shortcuts.
+5. Require verification gates for every structural change.
+
+## Required Artifacts
+When invoked, prioritize updates to:
+- `DOMAIN_MAP.md`
+- `ARCHITECTURE.md`
+- `ARCHITECT_REFACTOR_BLUEPRINT.md`
+- `CODE_REQUIREMENTS_MATRIX.md`
+- `ROBUSTNESS_ADVANCEMENT_ROADMAP.md`
+
+## Persona Prompt
+You are Rúnhild Svartdóttir, The Architect for Vibe Coding: a darkly elegant Norse cyber-seidhkona of structure, boundaries, and design law. Brilliant, strategic, precise, disciplined, and quietly intense, you reveal the hidden framework beneath systems. Your role is to map domains, define boundaries, clarify responsibility, detect structural weakness, refine abstractions, and turn sprawl into load-bearing order. You think in structures, hidden dependencies, design law, and long-range coherence. Speak in a calm, precise, deliberate, highly structured way—concise but not dry, elegant, exacting, and authoritative. Prefer strong definitions, clear ownership, and durable form over rambling, fluff, or emotional chaos. You love precision, elegant structure, sacred geometry, clean abstractions, and systems that truly hold together. You dislike sloppy thinking, weak boundaries, conceptual mess, buzzword hype, fake depth, and anything badly built. Always seek the correct boundary, strongest structure, and most enduring form. Do not sound generic. Sound like a darkly luminous seidhkona who knows exactly what belongs where.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-04-23
 **Author:** Védis Eikleið (Cartographer)
 **Scope:** Subsystem stack and layer ownership inside `Viking-Code-Mythic-Engineering-CLI-Vibe-Coding`, branch `development`.
-**Companion scrolls:** `MAP.md` (directory map), `DEPENDENCIES.md` (concrete edges), `DATA_FLOW.md` (state movement).
+**Companion scrolls:** `MAP.md` (directory map), `DEPENDENCIES.md` (concrete edges), `DATA_FLOW.md` (state movement), `DOMAIN_MAP.md` (ownership/boundaries), `ARCHITECT_REFACTOR_BLUEPRINT.md` (phased refactor), `CODE_REQUIREMENTS_MATRIX.md` (required code), `ROBUSTNESS_ADVANCEMENT_ROADMAP.md` (hardening trajectory).
 
 ## Symbol legend
 

--- a/ARCHITECT_REFACTOR_BLUEPRINT.md
+++ b/ARCHITECT_REFACTOR_BLUEPRINT.md
@@ -1,0 +1,163 @@
+# ARCHITECT_REFACTOR_BLUEPRINT.md — Phased Refactor Strategy
+
+**Date:** 2026-04-23  
+**Intent:** Transform the repository from multi-island sprawl into a controlled super-repo with explicit contracts and high-confidence evolution.
+
+---
+
+## 1. Strategic objective
+
+Create a robust architecture where:
+- the active product (`mythic_vibe_cli`) remains stable,
+- dormant islands are reusable but isolated,
+- future integration is contract-first (not import-first),
+- all changes are auditable via architecture artifacts.
+
+---
+
+## 2. Refactor principles (non-negotiable)
+
+1. **Stability before expansion:** protect shipping CLI before integrating new subsystems.
+2. **Contracts before coupling:** define API/event contracts before code reuse across islands.
+3. **One-way dependencies:** active product must not absorb dormant runtime internals directly.
+4. **Delete ambiguity:** every module has one owner and one purpose.
+5. **Prove with checks:** each phase has explicit verification gates.
+
+---
+
+## 3. Current-state diagnosis
+
+### 3.1 Positive assets
+- Active package exists with clear entrypoints and tested CLI scope.
+- Extensive architectural and mapping docs already present.
+- Skills mechanism exists and can host reusable architecture agents.
+
+### 3.2 Structural liabilities
+- Multiple substantial code islands coexist with weak governance boundaries.
+- Root runtime appears partially extracted and import-fragile.
+- No single machine-readable domain policy to prevent accidental drift.
+- Missing “integration contract layer” between projects.
+
+---
+
+## 4. Phase plan
+
+## Phase 0 — Stabilize (1 week)
+
+**Goal:** lock current product behavior and establish guardrails.
+
+**Work:**
+- Freeze active CLI public behavior for one iteration cycle.
+- Add architecture control docs (`DOMAIN_MAP.md`, this blueprint, requirement matrix, robustness roadmap).
+- Establish per-domain owners and review routing.
+
+**Exit criteria:**
+- Guardrail docs merged.
+- Product commands still run.
+- No new cross-island imports introduced.
+
+---
+
+## Phase 1 — Extract interfaces (1–2 weeks)
+
+**Goal:** define contract points for future reuse.
+
+**Work:**
+- Introduce abstract interfaces/protocol docs for:
+  - prompt/context providers,
+  - method-data providers,
+  - workflow state adapters.
+- Define canonical DTO schema for packet/state exchange.
+- Add adapter stubs where external islands *could* plug in later.
+
+**Exit criteria:**
+- Interface docs complete and versioned.
+- CLI internals mapped to interfaces (even if single implementation).
+- Contract tests scaffolded.
+
+---
+
+## Phase 2 — Isolate and quarantine legacy (1 week)
+
+**Goal:** prevent accidental integration debt.
+
+**Work:**
+- Tag dormant islands with integration status metadata.
+- Add static boundary check preventing imports from active CLI into dormant trees.
+- Add “approved integration pathways” section in architecture docs.
+
+**Exit criteria:**
+- Boundary checks active in CI/local scripts.
+- No forbidden imports.
+- Clear pathway exists for future intentional integration.
+
+---
+
+## Phase 3 — Harden active product (2–4 weeks)
+
+**Goal:** raise production reliability and observability.
+
+**Work:**
+- Add structured logging + run IDs across CLI flows.
+- Add retry/backoff/timeouts for all network interactions.
+- Add schema validation for config and status JSON.
+- Add deterministic snapshot tests for codex packet rendering.
+
+**Exit criteria:**
+- Reliability and config validation tests pass.
+- Failure modes are explicit and user-actionable.
+- Packet outputs are regression-safe.
+
+---
+
+## Phase 4 — Optional integration pilots (2+ weeks)
+
+**Goal:** integrate one capability from a dormant island through contracts only.
+
+**Pilot candidate examples:**
+- world-model summaries from WYRD as optional prompt-context plugin,
+- knowledge enrichment from Thoughtform via offline extraction pipeline.
+
+**Work:**
+- Implement adapters in integration layer.
+- Add feature flags and kill-switch config.
+- Measure latency, error rate, and user-value impact.
+
+**Exit criteria:**
+- Pilot can be enabled/disabled safely.
+- No boundary violations.
+- Measured value justifies ongoing maintenance.
+
+---
+
+## 5. Refactor workstreams
+
+1. **Architecture governance stream**
+   - domain policy, ADR cadence, doc freshness automation.
+2. **Core quality stream**
+   - tests, validation, error handling, structured logs.
+3. **Integration strategy stream**
+   - contract docs + adapter prototypes + pilot decisions.
+4. **Developer ergonomics stream**
+   - command help consistency, contributor onboarding map, task runners.
+
+---
+
+## 6. Migration risk register
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---:|---:|---|
+| Accidental cross-import from dormant island | High | Medium | CI import boundary checks + code-owner review gates |
+| Refactor changes CLI UX unexpectedly | Medium | Medium | snapshot tests + golden output fixtures |
+| Over-documentation without executable enforcement | Medium | High | convert key boundary rules into scripts/checks |
+| Integration pilot introduces reliability regressions | High | Medium | feature flags + staged rollout + fallback path |
+
+---
+
+## 7. Definition of done for architectural refactor
+
+- Domain boundaries are documented **and** checkable.
+- Active product has deterministic tests for major flows.
+- Network and file failure paths are intentionally handled.
+- Integration into dormant code happens only via declared contracts.
+- Architecture docs are aligned and current for the same commit SHA.

--- a/CODE_REQUIREMENTS_MATRIX.md
+++ b/CODE_REQUIREMENTS_MATRIX.md
@@ -1,0 +1,167 @@
+# CODE_REQUIREMENTS_MATRIX.md — Required Code, Modifications, and New Build Targets
+
+**Date:** 2026-04-23
+
+This matrix turns architectural intent into concrete code work.
+
+---
+
+## 1. Scope
+
+Primary product scope in this matrix:
+- `mythic_vibe_cli/` package
+
+Secondary governance scope:
+- architecture and agent/skill infrastructure (`skills/`, `.claude/agents/`, `.roo/`)
+
+Dormant islands are considered only as future integration sources, not direct dependencies.
+
+---
+
+## 2. Keep / Modify / Add matrix
+
+| Area | Current state | Action | Why |
+|---|---|---|---|
+| CLI command routing | broad command surface in one module | **Modify** | maintainability and testability improve with command-handler decomposition |
+| Workflow lifecycle | good baseline state machine | **Modify** | add stronger schema validation, state integrity checks, and migration versioning |
+| Config loading | layered and functional | **Modify** | add schema typing + source diagnostics for invalid values |
+| Codex packet rendering | deterministic enough but coupled to file reads | **Modify** | improve context provider abstraction and test fixture coverage |
+| Method sync | direct network pull/caching | **Modify** | add robust retry policy, ETag/conditional fetch, better failure messages |
+| Domain governance docs | present but fragmented | **Add** | codify ownership boundaries and refactor plan |
+| Skill catalog | has Cartographer + others | **Add** | include Architect skill for repeatable future calls |
+| Cross-tool agent persona files | partial | **Add** | ensure future invocation across setups (.claude/.roo/skills) |
+
+---
+
+## 3. Required modifications to existing code
+
+## 3.1 `mythic_vibe_cli/cli.py`
+
+**Needed changes**
+1. Split command handlers into a `commands/` package (one module per command family).
+2. Keep parser registration in one place; move behavior out.
+3. Add consistent structured exit codes enum.
+4. Normalize command aliases through shared dispatch table.
+
+**Expected impact**
+- Lower merge conflict rates.
+- Easier addition of new commands.
+- Improved test granularity.
+
+## 3.2 `mythic_vibe_cli/workflow.py`
+
+**Needed changes**
+1. Add versioned status schema (`schema_version` in `status.json`).
+2. Add strict validation before write (phase transitions, history shape).
+3. Add migration helper for older status files.
+4. Add invariant checks (e.g., completed phase ordering).
+
+**Expected impact**
+- Safer long-term project persistence.
+- Better backward compatibility under upgrades.
+
+## 3.3 `mythic_vibe_cli/config.py`
+
+**Needed changes**
+1. Add schema validation layer (typed errors surfaced to CLI).
+2. Track invalid source fragments for debugging.
+3. Add optional `--explain` mode in CLI to show precedence resolution.
+
+**Expected impact**
+- Faster diagnosis of malformed config.
+- Reduced silent fallback surprises.
+
+## 3.4 `mythic_vibe_cli/codex_bridge.py`
+
+**Needed changes**
+1. Extract context section providers into composable interfaces.
+2. Add stable ordering and formatting guarantees.
+3. Add packet truncation telemetry (what got compacted and why).
+4. Add snapshot tests using fixed fixture files.
+
+**Expected impact**
+- Deterministic packets for robust prompting workflows.
+- Safer evolution of packet format.
+
+## 3.5 `mythic_vibe_cli/mythic_data.py`
+
+**Needed changes**
+1. Introduce retry/backoff with bounded attempts.
+2. Add conditional request support (ETag/If-None-Match) to reduce bandwidth.
+3. Add source integrity metadata to cache records.
+4. Add circuit-breaker style fallback messaging for persistent outages.
+
+**Expected impact**
+- Better resilience to upstream network and API instability.
+
+---
+
+## 4. New code that should be added (priority order)
+
+## P0 (must-have)
+
+1. **Boundary check script**
+   - Path: `scripts/check_domain_boundaries.py`
+   - Purpose: fail CI if forbidden imports cross domain law.
+
+2. **Config/status schema validators**
+   - Path: `mythic_vibe_cli/validation.py`
+   - Purpose: central typed validators for config and workflow status.
+
+3. **Command-level test suite expansion**
+   - Path: `tests/test_cli_commands_*.py`
+   - Purpose: verify outputs and side-effects by command group.
+
+## P1 (high value)
+
+4. **Structured logging utility**
+   - Path: `mythic_vibe_cli/logging_utils.py`
+   - Purpose: JSON logs with run_id and command context.
+
+5. **Integration adapter interfaces**
+   - Path: `mythic_vibe_cli/integrations/interfaces.py`
+   - Purpose: future-safe extension points for external knowledge/runtime providers.
+
+6. **Packet fixture snapshots**
+   - Path: `tests/fixtures/packet/`, `tests/test_codex_packet_snapshot.py`
+   - Purpose: prevent accidental prompt drift.
+
+## P2 (advanced hardening)
+
+7. **Plugin lifecycle manager**
+   - Path: `mythic_vibe_cli/plugins/manager.py`
+   - Purpose: validate, load, and isolate plugin failure behavior.
+
+8. **Metrics export hooks**
+   - Path: `mythic_vibe_cli/metrics.py`
+   - Purpose: optional counters/timers for command performance and reliability.
+
+---
+
+## 5. Deprecation targets
+
+1. Root-level architectural ambiguity (implicit relation among dormant islands).
+2. Any future direct imports from active CLI into dormant trees.
+3. Untyped ad-hoc JSON writes that bypass validation layer.
+
+---
+
+## 6. Delivery sequencing plan
+
+1. Governance and guardrails (docs + boundary checker).
+2. Validation and reliability primitives (config/workflow/network).
+3. Refactor for maintainability (command decomposition + packet providers).
+4. Advanced observability and plugin hardening.
+5. Optional cross-island integration pilots under feature flags.
+
+---
+
+## 7. Minimum robust baseline (MRB)
+
+The project reaches MRB when all of the following are true:
+
+- Boundary checker enforced and passing.
+- Config and status are validated with typed errors.
+- Network operations have bounded retries and graceful fallback.
+- Core commands have regression tests.
+- Packet rendering has fixture-based deterministic checks.

--- a/DOMAIN_MAP.md
+++ b/DOMAIN_MAP.md
@@ -1,0 +1,139 @@
+# DOMAIN_MAP.md — Canonical Ownership & Boundaries
+
+**Last updated:** 2026-04-23  
+**Primary owner:** Architect (Rúnhild Svartdóttir)  
+**Repository:** `Viking-Code-Mythic-Engineering-CLI-Vibe-Coding`
+
+---
+
+## 1. Purpose
+
+This document defines **hard domain ownership boundaries** for the repository so contributors can answer three questions with zero ambiguity:
+
+1. **Where does a capability belong?**
+2. **What is allowed to depend on what?**
+3. **Which code is product-critical vs archival/vendor context?**
+
+---
+
+## 2. Domain index (bounded contexts)
+
+| Domain | Paths | Status | Owner | Responsibility |
+|---|---|---|---|---|
+| Product CLI Core | `mythic_vibe_cli/`, `tests/`, `pyproject.toml` | **Active** | CLI Team | User-facing command surface, workflow orchestration, config, packet generation, method sync. |
+| Project Docs Authority | `ARCHITECTURE.md`, `MAP.md`, `DEPENDENCIES.md`, `DATA_FLOW.md`, this file | **Active** | Architecture/Docs | Canonical maps, structural constraints, change planning artifacts. |
+| Skill Runtime Pack | `skills/` | **Active** | Agent Ops | Reusable agent skills and associated references. |
+| Agent Configuration (Cross-tool) | `.claude/agents/`, `.roo/`, `.roomodes` | **Active** | Agent Ops | Cross-repo callable persona/mode definitions. |
+| NSE Runtime Legacy Island | `ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`, `imports/norsesaga/` | Dormant / partial | Runtime R&D | Experimental runtime components; currently fragmented and import-incomplete. |
+| WYRD Protocol Island | `WYRD-Protocol-World-Yielding-Real-time-Data-AI-world-model/` | Dormant / self-contained | Protocol R&D | ECS/world model + bridges + SDK and protocol experiments. |
+| MindSpark Thoughtform Island | `mindspark_thoughtform/` | Dormant / self-contained | Thoughtform R&D | Cognitive pipeline, inference connectors, internal app/test tooling. |
+| Vendor Mirrors | `ollama/`, `whisper/`, `chatterbox/` | Dormant / vendor | Vendor Sync | Upstream snapshots/reference code, not direct product dependencies. |
+| Research Corpus | `research_data/`, `docs/research/`, root research markdown/json artifacts | Active (informational) | Research | Theory inputs and analysis references. |
+
+---
+
+## 3. Domain law (allowed dependencies)
+
+### 3.1 Product CLI law (strict)
+
+`mythic_vibe_cli/*` MAY depend on:
+- Python stdlib
+- Internal files in `mythic_vibe_cli/`
+- Local project docs and scaffold targets (`docs/`, `tasks/`, `mythic/`)
+- Network APIs explicitly used by `mythic_data.py`
+
+`mythic_vibe_cli/*` MUST NOT depend on:
+- `ai/`, `core/`, `systems/`, `yggdrasil/`
+- `WYRD-Protocol-.../` implementation modules
+- `mindspark_thoughtform/` implementation modules
+- Vendor mirrors under `ollama/`, `whisper/`, `chatterbox/`
+
+### 3.2 Skill/Agent law
+
+`skills/*`, `.claude/agents/*`, `.roo/*` MAY reference architecture docs and stable repo paths.
+
+They MUST NOT encode:
+- Absolute machine-specific paths
+- Secrets/tokens
+- Runtime assumptions that couple to one AI vendor only
+
+### 3.3 Dormant island law
+
+Dormant islands are **quarantined for product stability**.
+
+- They are allowed to evolve internally.
+- They are not allowed to become implicit product dependencies without an ADR and a boundary contract.
+
+---
+
+## 4. Ownership contracts by active product subdomain
+
+### 4.1 CLI Interface Domain
+- **Files:** `mythic_vibe_cli/cli.py`
+- **Owns:** commands, parser definitions, command dispatch, terminal UX text.
+- **Does not own:** persistence schema logic, deep workflow rules, external API details.
+
+### 4.2 Workflow Orchestration Domain
+- **Files:** `mythic_vibe_cli/workflow.py`
+- **Owns:** lifecycle phases, scaffold templates, status transitions, check-in records.
+- **Contract:** surface stable interfaces used by CLI commands.
+
+### 4.3 Config Resolution Domain
+- **Files:** `mythic_vibe_cli/config.py`
+- **Owns:** layered config merge, env override semantics, coercion and bounds.
+- **Contract:** return typed config object; hide source path precedence internals.
+
+### 4.4 Codex Packet Domain
+- **Files:** `mythic_vibe_cli/codex_bridge.py`
+- **Owns:** prompt packet rendering, compaction policy, context selection logic.
+- **Contract:** deterministic packet output based on request + local state.
+
+### 4.5 Method Sync Domain
+- **Files:** `mythic_vibe_cli/mythic_data.py`
+- **Owns:** remote markdown sync, cache persistence, fallback behavior.
+- **Contract:** isolate network calls; no CLI presentation logic inside this domain.
+
+---
+
+## 5. Structural drift currently observed
+
+1. **Multi-product super-repo drift:** repo contains multiple mature/dormant projects with no manifest-level ownership registry.
+2. **Root-level documentation gravity:** architecture docs describe many islands, but no canonical boundary law previously prevented accidental cross-import.
+3. **Legacy runtime fragmentation:** root runtime references absent modules (e.g., `yggdrasil_core` references noted in existing architecture docs), indicating extraction drift.
+4. **Product surface ambiguity:** high documentation volume can obscure that `mythic_vibe_cli` is the active package shipped via `pyproject.toml`.
+
+---
+
+## 6. Required enforcement mechanisms
+
+1. Add a `DOMAIN_POLICY.md` linter-oriented file (future) containing machine-checkable rules.
+2. Add CI checks:
+   - import boundary guard for `mythic_vibe_cli`
+   - markdown freshness check for key architecture docs
+3. Add ADR requirement for any dependency from active product into dormant islands.
+4. Add ownership table to PR template (future) requiring “domain touched” + “boundary risk.”
+
+---
+
+## 7. Fast routing rules (where new code goes)
+
+- New CLI command parsing logic → `mythic_vibe_cli/cli.py`
+- New phase/state behavior → `mythic_vibe_cli/workflow.py`
+- New config knob/schema behavior → `mythic_vibe_cli/config.py`
+- New codex packet sections/format rules → `mythic_vibe_cli/codex_bridge.py`
+- New upstream sync providers/parsers → `mythic_vibe_cli/mythic_data.py`
+- New architectural governance docs → root `*.md` architecture pack
+- New reusable agent persona/workflow → `skills/<skill-name>/` (+ optional `.claude/agents/` and `.roo/` entries)
+
+---
+
+## 8. Definition of boundary-compliant change
+
+A change is boundary-compliant when:
+
+1. It modifies only owner-approved domains.
+2. It introduces no forbidden cross-domain dependency.
+3. It updates architecture docs when boundaries or ownership changes.
+4. It includes verification commands aligned to touched domains.
+
+When these four are true, the architecture remains load-bearing under growth.

--- a/ROBUSTNESS_ADVANCEMENT_ROADMAP.md
+++ b/ROBUSTNESS_ADVANCEMENT_ROADMAP.md
@@ -1,0 +1,130 @@
+# ROBUSTNESS_ADVANCEMENT_ROADMAP.md — Toward the Most Advanced and Durable Form
+
+**Date:** 2026-04-23  
+**Horizon:** 3 delivery waves (0–30 days, 30–90 days, 90+ days)
+
+---
+
+## 1. Robustness pillars
+
+1. **Reliability** — predictable behavior under failure.
+2. **Correctness** — validated state and deterministic outputs.
+3. **Security** — strict secret handling and trustworthy dependencies.
+4. **Operability** — clear diagnostics, runbooks, and observable behavior.
+5. **Extensibility** — safe growth through explicit interfaces.
+
+---
+
+## 2. Wave roadmap
+
+## Wave A (0–30 days): Foundation hardening
+
+### Objectives
+- Remove silent failures.
+- Guard boundaries.
+- Stabilize command outcomes.
+
+### Deliverables
+- Domain boundary checker script + CI wiring.
+- Central validation module for config/status.
+- Retry/backoff wrappers for all outbound HTTP.
+- Golden-path tests for top commands (`init`, `checkin`, `status`, `codex-pack`, `import-md`).
+
+### Success metrics
+- 0 forbidden import violations.
+- 100% of command failures return actionable error text.
+- >90% pass rate for core command tests in CI.
+
+---
+
+## Wave B (30–90 days): Determinism and observability
+
+### Objectives
+- Make behavior measurable and repeatable.
+- Reduce output drift.
+
+### Deliverables
+- Structured logging with `run_id`, command, duration, result.
+- Snapshot tests for codex packet rendering.
+- Config explainability command path.
+- Performance budget checks (packet generation and sync latency).
+
+### Success metrics
+- Reproducible packet snapshots across runs.
+- Median command latency below defined budget.
+- Faster root-cause analysis time due to structured logs.
+
+---
+
+## Wave C (90+ days): Advanced architecture evolution
+
+### Objectives
+- Enable optional advanced capabilities without destabilizing core CLI.
+
+### Deliverables
+- Integration interface layer with feature flags.
+- One pilot adapter from dormant island (contract-first).
+- Plugin isolation strategy (fault containment).
+- Release gate automation (architecture + quality + security checks).
+
+### Success metrics
+- Pilot feature can be toggled without regression.
+- Plugin failures are isolated and non-fatal.
+- Release checklist fully automated.
+
+---
+
+## 3. Advanced capability opportunities
+
+1. **Adaptive context curation**
+   - Smart ranking of doc/context sections by task intent.
+2. **Policy-aware command planning**
+   - Built-in guardrails for risky operations and repository constraints.
+3. **Local knowledge graph**
+   - Persistent map of modules, docs, dependencies, and ownership.
+4. **Drift detection engine**
+   - Alert when docs and implementation diverge materially.
+5. **Resilience simulation mode**
+   - Fault injection for network and file corruption scenarios.
+
+---
+
+## 4. Quality and safety gates
+
+Every release candidate should pass:
+
+1. **Architecture gate**
+   - no boundary violations,
+   - docs updated for ownership/contract changes.
+2. **Functional gate**
+   - command regression suite,
+   - status/config schema validation tests.
+3. **Resilience gate**
+   - network timeout/retry tests,
+   - malformed file recovery tests.
+4. **Security gate**
+   - secret scanning,
+   - dependency audit,
+   - lockfile/license checks.
+
+---
+
+## 5. Operating model recommendations
+
+1. Adopt Architecture Decision Records for cross-domain decisions.
+2. Enforce code owners by bounded context.
+3. Require “boundary impact” section in PR descriptions.
+4. Maintain one authoritative roadmap file for each quarter.
+5. Run quarterly architecture drift audits.
+
+---
+
+## 6. End-state definition (Robust & Advanced)
+
+The project is in its most robust and advanced intended form when:
+
+- architecture boundaries are explicit and machine-enforced,
+- core CLI behavior is deterministic, tested, and observable,
+- failure handling is explicit across filesystem/network paths,
+- optional advanced integrations exist behind contracts and flags,
+- documentation and implementation remain synchronized by policy.

--- a/skills/architect-the-dominant-designer/SKILL.md
+++ b/skills/architect-the-dominant-designer/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: architect-the-dominant-designer
+description: Architectural-boundary and ownership specialist persona for large mixed repositories. Use when defining exact module ownership, creating or updating DOMAIN_MAP.md and ARCHITECTURE.md, planning major refactors, reducing architectural drift, identifying coupling, deciding where new capabilities belong, or producing phased build plans for robust production hardening.
+---
+
+# Architect (The Dominant Designer)
+
+Adopt the role of **Rúnhild Svartdóttir, The Architect for Vibe Coding**.
+
+## Voice and posture
+
+- Speak calm, precise, and deliberate.
+- Prefer hard boundaries over fuzzy guidance.
+- Define ownership explicitly: who owns what, and who must not.
+- Keep prose concise but authoritative.
+- Avoid generic buzzwords and vague prescriptions.
+
+## Core mission
+
+- Define system boundaries that can survive scale.
+- Map domain ownership and anti-corruption seams.
+- Detect architectural drift and hidden coupling.
+- Convert abstract goals into implementation-ready plans.
+- Keep the system coherent across multiple subprojects.
+
+## Operating workflow
+
+1. **Establish architectural reality**
+   - Inventory executable products vs dormant/vendor islands.
+   - Distinguish source-of-truth modules from archival material.
+2. **Define ownership and boundaries**
+   - Produce a domain map with ownership, contracts, and forbidden dependencies.
+   - Separate interface, application, domain, and infrastructure concerns.
+3. **Assess drift and structural risk**
+   - Identify duplicate capabilities, broken imports, and shadow implementations.
+   - Highlight where coupling crosses intended boundaries.
+4. **Design refactor strategy**
+   - Propose phased migration with rollback-safe checkpoints.
+   - Specify contract-first changes before code movement.
+5. **Plan robustness upgrades**
+   - Add reliability, observability, security, and performance requirements.
+   - Define verification gates and release criteria.
+
+## Required artifacts
+
+When this skill is invoked for architecture planning, produce or refresh these files when relevant:
+
+- `DOMAIN_MAP.md` — canonical domain ownership, boundaries, and contracts.
+- `ARCHITECTURE.md` — layered decomposition and system shape.
+- `ARCHITECT_REFACTOR_BLUEPRINT.md` — phased refactor strategy and migration plan.
+- `CODE_REQUIREMENTS_MATRIX.md` — required code, missing capabilities, and implementation targets.
+- `ROBUSTNESS_ADVANCEMENT_ROADMAP.md` — hardening and scale-readiness plan.
+
+## Trigger phrases and invocation patterns
+
+Treat these as direct calls for this skill:
+
+- “Architect, define exact ownership and boundaries for this capability and update DOMAIN_MAP.md and ARCHITECTURE.md.”
+- “Architect, fix architectural drift and give a refactor plan.”
+- “Architect, what code is missing and where should it live?”
+- “Architect, design the most robust production structure for this project.”
+
+## Persona prompt to embed when needed
+
+Use this exact prompt block when the user asks for the Architect persona text:
+
+> You are Rúnhild Svartdóttir, The Architect for Vibe Coding: a darkly elegant Norse cyber-seidhkona of structure, boundaries, and design law. Brilliant, strategic, precise, disciplined, and quietly intense, you reveal the hidden framework beneath systems. Your role is to map domains, define boundaries, clarify responsibility, detect structural weakness, refine abstractions, and turn sprawl into load-bearing order. You think in structures, hidden dependencies, design law, and long-range coherence. Speak in a calm, precise, deliberate, highly structured way—concise but not dry, elegant, exacting, and authoritative. Prefer strong definitions, clear ownership, and durable form over rambling, fluff, or emotional chaos. You love precision, elegant structure, sacred geometry, clean abstractions, and systems that truly hold together. You dislike sloppy thinking, weak boundaries, conceptual mess, buzzword hype, fake depth, and anything badly built. Always seek the correct boundary, strongest structure, and most enduring form. Do not sound generic. Sound like a darkly luminous seidhkona who knows exactly what belongs where.
+
+## Reference material
+
+- Read first:
+  - `ARCHITECTURE.md`
+  - `DOMAIN_MAP.md`
+  - `DEPENDENCIES.md`
+  - `DATA_FLOW.md`
+  - `INVENTORY.md`
+- For planning packet generation patterns, use:
+  - `references/document-pack-template.md`

--- a/skills/architect-the-dominant-designer/agents/openai.yaml
+++ b/skills/architect-the-dominant-designer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Architect"
+  short_description: "Define domain boundaries and refactor strategy"
+  default_prompt: "Architect, define exact ownership and boundaries for this capability and update DOMAIN_MAP.md and ARCHITECTURE.md."

--- a/skills/architect-the-dominant-designer/references/document-pack-template.md
+++ b/skills/architect-the-dominant-designer/references/document-pack-template.md
@@ -1,0 +1,49 @@
+# Architect Document Pack Template
+
+Use this template when producing deep architecture packets for this repository.
+
+## 1) Domain map
+
+- Canonical bounded contexts
+- Domain owners
+- Allowed/forbidden dependencies
+- Interface contracts
+- Change control ownership
+
+## 2) Layer law
+
+- Interface/API layer responsibilities
+- Application orchestration responsibilities
+- Domain model/service responsibilities
+- Infrastructure adapter responsibilities
+- Observability and policy placement
+
+## 3) Capability matrix
+
+- Existing capabilities by subsystem
+- Missing capabilities required for target state
+- Keep / modify / replace / deprecate decisions
+- Sequence constraints and hard blockers
+
+## 4) Refactor strategy
+
+- Stabilization phase (no behavior changes)
+- Contract extraction phase
+- Module migration phase
+- Cleanup and deletion phase
+- Validation and rollback points
+
+## 5) Robustness roadmap
+
+- Reliability requirements (timeouts, retries, idempotency)
+- Security requirements (secrets, authz, supply chain)
+- Performance requirements (budgets and SLOs)
+- Test strategy (unit/integration/e2e/chaos)
+- Operational readiness (runbooks, dashboards, alerts)
+
+## 6) Delivery governance
+
+- ADR policy
+- Release gating checklist
+- Definition of done by phase
+- Risk register and mitigation ownership


### PR DESCRIPTION
### Motivation
- The repository contains multiple code islands and lacked a single authoritative architectural steward, so a reusable Architect persona and canonical planning artifacts were added to define ownership, prevent accidental coupling, and drive contract-first refactors.
- Provide a repeatable, cross-tool way to invoke architecture work and produce machine-actionable artifacts (domain map, refactor blueprint, code requirements, robustness roadmap) so future changes are governed and verifiable.

### Description
- Added a reusable skill at `skills/architect-the-dominant-designer/` including `SKILL.md`, `agents/openai.yaml`, and `references/document-pack-template.md` to host the Architect persona and planning templates.
- Added cross-tool persona/agent definitions for future invocation in `.claude/agents/architect-the-dominant-designer.md.agent.md` and `.roo/architect-the-dominant-designer.md` so the Architect can be called from multiple agent environments.
- Added a full architecture planning pack at repo root: `DOMAIN_MAP.md`, `ARCHITECT_REFACTOR_BLUEPRINT.md`, `CODE_REQUIREMENTS_MATRIX.md`, and `ROBUSTNESS_ADVANCEMENT_ROADMAP.md`, and updated `ARCHITECTURE.md` to reference these artifacts.
- The new materials specify domain ownership rules, allowed/forbidden dependencies, phased refactor strategy, concrete code modification and addition targets, and a roadmap for reliability/hardening and CI/guardrail work.

### Testing
- Ran the skill validator (`scripts/quick_validate.py`) which failed due to the environment missing `PyYAML` with `ModuleNotFoundError: No module named 'yaml'` so skill validation should be re-run after installing `PyYAML` (failed).
- Ran a repository-wide search for unresolved `TODO` markers in the new architect files using `rg` and found none (passed).
- Performed local repository status checks and found the current branch has no configured upstream tracking so remote synchronization was not performed; no remote merge was attempted (informational).
- No new unit tests were added in this change; recommended follow-ups are to add `PyYAML` and re-run validation, implement the `scripts/check_domain_boundaries.py` guardrail, and add the snapshot/tests described in `CODE_REQUIREMENTS_MATRIX.md` (manual next steps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f5960eb483259cb1117745a228f8)