### PR TITLE
Add SYSTEM_VISION document to docs/

### DIFF
--- a/docs/SYSTEM_VISION.md
+++ b/docs/SYSTEM_VISION.md
@@ -1,0 +1,96 @@
+# SYSTEM VISION
+
+## Purpose
+
+Mythic Vibe CLI exists to make disciplined software creation accessible to ordinary builders by turning architectural intent into repeatable execution loops.
+
+The system should feel like a trusted co-navigator: structured enough to prevent drift, flexible enough to preserve creativity, and explicit enough to keep teams aligned over time.
+
+## North Star
+
+Enable any individual or small team to move from idea to resilient implementation through a clear, phase-based method:
+
+`intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
+
+Success means users can repeatedly ship coherent work with less confusion, fewer rewrites, and better documentation continuity.
+
+## Product Promises
+
+1. **Architecture-first by default**  
+   The CLI should always steer users to define goals, constraints, and design decisions before coding.
+
+2. **Beginner-friendly, expert-capable**  
+   Core workflows must remain understandable for new users while still supporting advanced users who want speed and depth.
+
+3. **Traceable progress**  
+   Every major action should leave a durable artifact (docs, plans, logs, status updates) so decisions can be audited and continued.
+
+4. **Low-friction human + AI collaboration**  
+   The system should support practical copy/paste collaboration with LLMs and preserve context through structured prompt packets.
+
+5. **Method fidelity without rigidity**  
+   The CLI should enforce healthy defaults while allowing intentional adaptation for project-specific realities.
+
+## Scope of the System
+
+### In scope
+- Project initialization with Mythic-aligned structure.
+- Workflow commands for planning, check-ins, diagnostics, and status.
+- Documentation scaffolding and method reinforcement.
+- Prompt packet generation and response logging for AI-assisted development.
+
+### Out of scope
+- Replacing engineering judgment.
+- Fully autonomous code generation without human review.
+- Locking users into one model provider or one coding style.
+
+## System Design Principles
+
+- **Clarity over cleverness:** command behavior should be legible and predictable.
+- **Artifacts over memory:** decisions belong in files, not in private context.
+- **Small loops, fast feedback:** prefer incremental progress with verification checkpoints.
+- **Stable defaults, configurable edges:** beginner-safe defaults with layered config for power users.
+- **Transparency over magic:** users should understand why the tool suggests or enforces a step.
+
+## User Experience Vision
+
+A user should be able to:
+1. Initialize or adopt a project rapidly.
+2. See what phase they are in and what “done” means for that phase.
+3. Generate AI collaboration context without leaking method structure.
+4. Record progress in seconds and return days later without losing thread.
+5. Diagnose project health quickly when momentum drops.
+
+## Quality Bar
+
+A high-quality Mythic Vibe CLI interaction is:
+- **Coherent:** commands reinforce a single mental model.
+- **Recoverable:** state can be inspected and repaired.
+- **Documented:** decisions and outcomes are captured.
+- **Composable:** workflows chain cleanly across phases.
+- **Trustworthy:** diagnostics and status reflect reality.
+
+## Evolution Path
+
+Near-term evolution should prioritize:
+1. Better phase guidance and error messages.
+2. Stronger diagnostics and remediation hints.
+3. Higher-signal prompt packet composition.
+4. Clearer project-level governance docs and templates.
+
+Long-term evolution may include:
+- Multi-agent orchestration patterns.
+- Richer retrieval and memory integrations.
+- Extended ritual command ecosystem with explicit safety rails.
+
+## Anti-Goals (Guardrails)
+
+The system should not become:
+- A black-box agent that hides decisions.
+- A brittle bureaucracy that blocks momentum.
+- A style-policing engine detached from project outcomes.
+- A vendor-locked workflow tied to one external service.
+
+## Final Vision Statement
+
+Mythic Vibe CLI is a practical engineering compass: a toolchain that helps humans and AI build software with stronger intent, clearer structure, and durable continuity from first idea to maintained system.


### PR DESCRIPTION
### Motivation
- Provide a concise system-level product vision for the Mythic Vibe CLI to anchor architecture and feature decisions, as requested via an invocation of the Skald-style vision document. 
- The change serves to codify purpose, north star, product promises, scope boundaries, design principles, UX goals, quality bar, evolution path, and anti-goals so future work remains aligned.

### Description
- Add a new file `docs/SYSTEM_VISION.md` containing a full system vision including Purpose, North Star, Product Promises, Scope, Design Principles, User Experience Vision, Quality Bar, Evolution Path, Anti-Goals, and a Final Vision Statement. 
- Content was written in a Skald/vision style and placed under the `docs/` directory to be used as a reference for future architecture and feature decisions. 
- The new file was staged and committed with the message `Add SYSTEM_VISION document under docs`.

### Testing
- Verified the working tree before and after the change with `git status --short`, which completed successfully. 
- Added and committed the new file using `git add docs/SYSTEM_VISION.md && git commit -m "Add SYSTEM_VISION document under docs"`, which completed successfully. 
- Printed the created file with `nl -ba docs/SYSTEM_VISION.md | sed -n '1,220p'` to confirm the file contents, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fd96f228832582c4eb976170e50b)