### PR TITLE
Add initial Cartographer repository overview

### DIFF
--- a/CARTOGRAPHER_OVERVIEW.md
+++ b/CARTOGRAPHER_OVERVIEW.md
@@ -1,0 +1,59 @@
+# CARTOGRAPHER_OVERVIEW.md — Initial Repository Overview
+
+**Date:** 2026-04-23  
+**Cartographer:** Védis Eikleið  
+**Repository:** `Viking-Code-Mythic-Engineering-CLI-Vibe-Coding`
+
+## 1) Terrain at a glance
+
+This repository is a **hybrid archive + active product repo**:
+
+- A small, active product: `mythic_vibe_cli/` (the Mythic Vibe CLI).
+- A large set of imported systems from earlier projects:
+  - Norse Saga Engine-style modules at root (`systems/`, `yggdrasil/`, `core/`, `ai/`).
+  - Full embedded subprojects (`mindspark_thoughtform/`, `WYRD-Protocol-.../`).
+- Three major vendored upstream projects (`ollama/`, `whisper/`, `chatterbox/`).
+
+## 2) Primary islands
+
+| Island | Role | Integration status |
+|---|---|---|
+| `mythic_vibe_cli/` + root `tests/` | Main runnable product and packaged Python code | **Active and coherent** |
+| `systems/`, `yggdrasil/`, `core/`, `ai/`, `sessions/` | Imported Norse Saga Engine components | **Partially connected, contains broken/ghost imports** |
+| `mindspark_thoughtform/` | Full embedded ThoughtForge project | **Mostly self-contained** |
+| `WYRD-Protocol-World-Yielding-Real-time-Data-AI-world-model/` | Full embedded WYRD project | **Mostly self-contained** |
+| `ollama/`, `whisper/`, `chatterbox/` | Vendored upstream dependencies | **Present, not actively wired into CLI** |
+
+## 3) Practical source of truth (today)
+
+For contributors trying to ship product value quickly, treat these as canonical first:
+
+1. `README.md` (user-facing CLI behavior)
+2. `pyproject.toml` (what is actually packaged)
+3. `mythic_vibe_cli/` (actual CLI code)
+4. `tests/` (tests that currently guard shipped CLI behavior)
+
+Then use map artifacts for deep orientation:
+
+- `MAP.md`
+- `ARCHITECTURE.md`
+- `DEPENDENCIES.md`
+- `DATA_FLOW.md`
+- `INVENTORY.md`
+
+## 4) Immediate integration risks to remember
+
+- Ghost imports exist in imported NSE code (example: references to modules not present in repo).
+- `wyrdforge` appears in multiple places with overlap/drift risk.
+- Root-level code quantity is very large compared with the actively packaged CLI.
+- Different subprojects assume different dependency stacks; one environment may not satisfy all simultaneously.
+
+## 5) Suggested north-star framing
+
+Treat this repository as:
+
+- **Core product lane:** `mythic_vibe_cli/` + root tests (keep stable, testable, releasable).
+- **Integration lane:** imported engines and subprojects (progressively reconciled behind clear boundaries).
+- **Archive lane:** theory/research corpus and vendored source trees retained for reference and future extraction.
+
+This framing reduces confusion, keeps shipping velocity in the CLI lane, and turns the rest of the terrain into deliberate integration work rather than accidental coupling.


### PR DESCRIPTION
### Motivation
- Provide a compact, system-level orientation of the repository so contributors can quickly understand major islands, integration risks, and where to focus effort before any deep integration work.

### Description
- Add `CARTOGRAPHER_OVERVIEW.md` documenting the repo terrain, primary islands (`mythic_vibe_cli/`, imported NSE code, embedded MindSpark and WYRD subprojects, vendored upstreams), practical sources of truth, immediate integration risks (ghost imports, duplicate `wyrdforge`, multi-stack dependency hazards), and a recommended `core/integration/archive` framing.

### Testing
- Verified repository changes with `git status --short`, added and committed the new file using `git add CARTOGRAPHER_OVERVIEW.md` and `git commit -m "Add initial Cartographer repository overview"`, and created the PR record via the `make_pr` helper; all commands completed successfully and no unit tests were run on product code for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea029260e0832587696582b528600e)