### PR TITLE
docs(yggdrasil): add folder-level INTERFACE.md contracts for domain packages

### DIFF
--- a/yggdrasil/config/INTERFACE.md
+++ b/yggdrasil/config/INTERFACE.md
@@ -1,0 +1,15 @@
+# yggdrasil.config — INTERFACE
+
+## Purpose
+Configuration surface for the Yggdrasil package.
+
+## Public Interface
+- `yggdrasil.config` package export via `__init__.py`.
+- `default.yaml` as the default runtime configuration payload.
+
+## Contracts
+- Consumers should treat `default.yaml` as baseline values and overlay environment/runtime-specific settings externally.
+- Config loading should remain side-effect free and deterministic.
+
+---
+**Contract Version**: 1.0 | v8.0.0

--- a/yggdrasil/core/INTERFACE.md
+++ b/yggdrasil/core/INTERFACE.md
@@ -1,0 +1,18 @@
+# yggdrasil.core — INTERFACE
+
+## Purpose
+Core orchestration primitives for Yggdrasil runtime behavior.
+
+## Public Interface
+- `bifrost.py` — bridge/routing orchestration core.
+- `dag.py` — dependency graph composition and traversal helpers.
+- `llm_queue.py` — queueing boundary for LLM work units.
+- `world_tree.py` — world-state tree orchestration.
+- `wyrd_system.py` — Wyrd runtime coordination surface.
+
+## Contracts
+- Core modules provide deterministic orchestration APIs for higher layers (`router*`, `worlds`, `integration`).
+- Data passed across module boundaries should be serializable and explicit (no hidden global mutation).
+
+---
+**Contract Version**: 1.0 | v8.0.0

--- a/yggdrasil/integration/INTERFACE.md
+++ b/yggdrasil/integration/INTERFACE.md
@@ -1,0 +1,15 @@
+# yggdrasil.integration — INTERFACE
+
+## Purpose
+External integration boundary between Yggdrasil and host systems.
+
+## Public Interface
+- `deep_integration.py` — deeper host/runtime coupling hooks.
+- `norse_saga.py` — Norse Saga Engine integration entrypoints.
+
+## Contracts
+- Integration adapters must preserve Yggdrasil core invariants while translating external payloads.
+- Failures should be surfaced as integration-layer errors without mutating upstream state.
+
+---
+**Contract Version**: 1.0 | v8.0.0

--- a/yggdrasil/ravens/INTERFACE.md
+++ b/yggdrasil/ravens/INTERFACE.md
@@ -1,0 +1,16 @@
+# yggdrasil.ravens — INTERFACE
+
+## Purpose
+Knowledge/recollection subsystem built around Huginn + Muninn patterns.
+
+## Public Interface
+- `huginn.py` — observation/intel collection interface.
+- `muninn.py` — memory/recollection interface.
+- `raven_rag.py` — retrieval-augmented composition over raven channels.
+
+## Contracts
+- Raven modules exchange normalized records suitable for retrieval and audit.
+- Retrieval flows should remain composable by higher-level routers.
+
+---
+**Contract Version**: 1.0 | v8.0.0

--- a/yggdrasil/tests/INTERFACE.md
+++ b/yggdrasil/tests/INTERFACE.md
@@ -1,0 +1,15 @@
+# yggdrasil.tests — INTERFACE
+
+## Purpose
+Verification surface for package-level and integration-level behavior.
+
+## Public Interface
+- `test_yggdrasil.py` as primary system behavior test module.
+- Additional package tests discovered by test runners from this directory.
+
+## Contracts
+- Tests validate externally visible behavior, not incidental internals.
+- Test fixtures should remain isolated and reproducible.
+
+---
+**Contract Version**: 1.0 | v8.0.0

--- a/yggdrasil/worlds/INTERFACE.md
+++ b/yggdrasil/worlds/INTERFACE.md
@@ -1,0 +1,15 @@
+# yggdrasil.worlds — INTERFACE
+
+## Purpose
+Domain model for Nine Worlds runtime environments.
+
+## Public Interface
+- `get_world(name)` factory via `__init__.py`.
+- Realm modules: `asgard`, `midgard`, `vanaheim`, `alfheim`, `jotunheim`, `svartalfheim`, `muspelheim`, `niflheim`, `helheim`.
+
+## Contracts
+- Each world module exposes a world-specific class/behavior model compatible with `get_world(name)` lookup.
+- Unknown world names must fail explicitly (no silent fallback).
+
+---
+**Contract Version**: 1.0 | v8.0.0


### PR DESCRIPTION
### Motivation
- Define canonical, folder-level interface contracts for the Yggdrasil package as part of the Scribe documentation pass to make domain boundaries and public surfaces explicit. 
- Provide a single-file reference per domain (`config`, `core`, `integration`, `ravens`, `worlds`, `tests`) to complement existing per-module `*_INTERFACE.md` files and reduce discovery friction.

### Description
- Added `yggdrasil/config/INTERFACE.md`, `yggdrasil/core/INTERFACE.md`, `yggdrasil/integration/INTERFACE.md`, `yggdrasil/ravens/INTERFACE.md`, `yggdrasil/worlds/INTERFACE.md`, and `yggdrasil/tests/INTERFACE.md` describing purpose, public interface surface, and contract expectations. 
- Each file uses the repository's contract header convention (`Contract Version: 1.0 | v8.0.0`) and calls out the primary modules or entrypoints expected to be stable. 
- These are documentation-only additions and make no runtime or codepath changes. 

### Testing
- Confirmed files are present and untracked changes surfaced via `git status --short`, which showed the six new files successfully staged. 
- Inspected contents with `head -n 5` and `nl -ba` on the new files to verify headings, sections, and contract footer were written as intended. 
- Committed the changes (`git commit`) and created the PR record using the repository PR tooling, and all automated steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea099bd5e48325b1ec827ded4d312e)