### PR TITLE
docs: expand and polish core documentation set

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,111 +1,122 @@
-# Architecture (Architect Invocation)
+# Architecture
 
 **Status:** Active architecture record  
 **Last updated:** 2026-04-23  
 **Owner:** Architecture / Docs
 
-This document is the `docs/` companion to the root-level `ARCHITECTURE.md`.  
-Use this version when you need a fast orientation and clear implementation boundaries.
+This document defines the active runtime architecture for this monorepo and the rules that prevent accidental coupling.
 
 ---
 
-## 1) System posture
+## 1) Repository posture
 
-The repository currently behaves as a **multi-project monorepo** with one primary executable product:
+Treat this repository as a **multi-project monorepo** with one primary live product path:
 
-1. **Mythic Vibe CLI** (`mythic_vibe_cli/`) — live operational path.
-2. **Norse Saga Engine runtime modules** (`ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`) — present, mostly dormant/incomplete wiring.
-3. **Embedded upstream/vendor trees** (`ollama/`, `whisper/`, `WYRD-.../`, and research/spec artifacts) — largely self-contained.
+1. **Mythic Vibe CLI** (`mythic_vibe_cli/`) — active runtime and operational entrypoint.
+2. **Legacy/runtime islands** (`ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`) — mostly dormant/fragmented.
+3. **Vendor/research islands** (`ollama/`, `whisper/`, `WYRD-.../`, specs/research corpora) — reference only unless explicitly integrated.
 
-Architecturally, treat these as **separate islands** until explicit integration contracts are introduced.
+Default assumption: islands are independent unless a documented adapter contract exists.
 
 ---
 
-## 2) Primary live architecture: Mythic Vibe CLI
+## 2) Active system flow (Mythic Vibe CLI)
 
 ```text
 User
   -> CLI Router (mythic_vibe_cli/cli.py)
-    -> Workflow Engine (workflow.py)
-    -> Codex Packet Builder (codex_bridge.py)
+    -> Workflow Orchestrator (workflow.py)
+    -> Prompt/Bridge Composer (codex_bridge.py)
     -> Config Resolution (config.py)
     -> Method Sync + Cache (mythic_data.py)
-      -> Filesystem state (docs/, tasks/, mythic/, DEVLOG.md, weave.db)
-      -> Optional GitHub method sync
+      -> Project artifacts (docs/, tasks/, mythic/, DEVLOG.md, weave.db)
+      -> Optional external sync providers
 ```
 
 ### Layer responsibilities
 
-- **Interface layer (`cli.py`)**
-  - Parses commands and options.
-  - Dispatches command handlers.
-- **Orchestration layer (`workflow.py`)**
-  - Maintains phased flow (intent → constraints → architecture → plan → build → verify → reflect).
-  - Manages operational project artifacts.
-- **Prompt/bridge layer (`codex_bridge.py`)**
-  - Builds prompt packets and context excerpts.
-  - Applies budget and compaction behavior.
-- **Configuration layer (`config.py`)**
-  - Resolves config precedence from local/user/env scopes.
-- **Data/method layer (`mythic_data.py`)**
-  - Pulls and caches method docs.
+- **`cli.py` (interface layer)**
+  - Defines commands/options and dispatches handlers.
+  - Keeps user-facing behavior coherent and predictable.
+
+- **`workflow.py` (orchestration layer)**
+  - Runs phase lifecycle and state transitions.
+  - Writes/updates durable artifacts.
+
+- **`codex_bridge.py` (prompt/packet layer)**
+  - Builds high-signal context packets.
+  - Applies compaction and budget constraints.
+
+- **`config.py` (configuration layer)**
+  - Resolves env/file/default precedence.
+  - Stays low-side-effect and stable.
+
+- **`mythic_data.py` (data/sync layer)**
+  - Handles method source sync/import/caching.
+  - Avoids owning orchestration logic.
 
 ---
 
-## 3) Architectural boundaries
+## 3) Dependency direction law
 
-### Hard boundaries (current)
+To keep architecture legible, dependency direction should remain one-way:
 
-- `mythic_vibe_cli/` should remain independently executable.
-- Root runtime trees (`core/`, `systems/`, `yggdrasil/`, etc.) are not assumed load-bearing for CLI execution.
-- Vendor/upstream folders should not be imported accidentally into CLI runtime paths.
+1. `cli.py` -> `workflow`, `codex_bridge`, `config`, `mythic_data`
+2. `workflow.py` -> `config` + local artifact IO
+3. `codex_bridge.py` -> `config` + prepared workflow context
+4. `config.py` -> minimal dependencies
+5. `mythic_data.py` -> sync/cache concerns only
 
-### Soft boundaries (planned)
-
-- Integration should occur via explicit adapters/interfaces rather than direct deep imports.
-- Cross-island reuse should be documented first (contract + data-flow + dependency impact), then wired.
-
----
-
-## 4) Dependency direction rules
-
-For maintainability, enforce one-way architectural flow in the live path:
-
-1. `cli.py` can depend on `workflow`, `codex_bridge`, `config`, `mythic_data`.
-2. `workflow.py` can depend on `config` and file-system state.
-3. `codex_bridge.py` can depend on `config` and prepared workflow artifacts.
-4. `config.py` should remain low-level and side-effect light.
-5. `mythic_data.py` can touch network/cache concerns but should not absorb CLI orchestration logic.
-
-If a change requires reversing this direction, treat it as an architecture decision and record it before merging.
+Any reversal requires an architecture decision record (ADR-style note in docs) before merge.
 
 ---
 
-## 5) Operational risks to monitor
+## 4) Boundary rules
 
-- **Monorepo ambiguity:** contributors may assume dormant modules are active runtime dependencies.
-- **Import drift:** accidental imports from unrelated islands can silently increase coupling.
-- **Docs drift:** root `ARCHITECTURE.md`, `DOMAIN_MAP.md`, and this file can diverge without regular refresh.
+### Hard boundaries
+
+- `mythic_vibe_cli/` remains independently executable.
+- Dormant islands are not implicit runtime dependencies.
+- Vendor mirrors are not direct product import targets.
+
+### Soft boundaries
+
+- Cross-island reuse must enter via explicit adapters/interfaces.
+- Document contracts and data flow before adding wiring.
 
 ---
 
-## 6) Architecture guardrails
+## 5) Architecture risks
 
-- Keep primary executable behavior centered in `mythic_vibe_cli/`.
-- Prefer composition/adapters over direct cross-tree imports.
-- Update architecture docs when introducing:
-  - a new runtime entrypoint,
-  - a new persistence contract,
-  - a new external dependency path,
-  - or any cross-island integration.
+- **Monorepo ambiguity:** contributors may edit the wrong island for active product behavior.
+- **Import drift:** accidental imports increase coupling and maintenance cost.
+- **Docs drift:** architecture/governance docs can diverge from runtime reality.
+
+Mitigation: require boundary verification commands in every meaningful PR.
+
+---
+
+## 6) Change protocol
+
+When a change introduces any of the following, update this file in the same PR:
+
+- new runtime entrypoint,
+- new persistence/state contract,
+- new external dependency path,
+- new cross-island integration,
+- significant command lifecycle change.
+
+Also update related records:
+
+- `docs/DOMAIN_MAP.md`
+- root `ARCHITECTURE.md`
+- `DATA_FLOW.md` (if data movement changed)
 
 ---
 
 ## 7) Related records
 
 - Root deep-dive: `ARCHITECTURE.md`
-- Domain boundaries: `docs/DOMAIN_MAP.md`
-- Data movement: `DATA_FLOW.md`
-- Concrete dependencies: `DEPENDENCIES.md`
-- Required-code matrix: `CODE_REQUIREMENTS_MATRIX.md`
-
+- Ownership boundaries: `docs/DOMAIN_MAP.md`
+- System direction: `docs/SYSTEM_VISION.md`
+- Operational flow details: `DATA_FLOW.md`

--- a/docs/DOMAIN_MAP.md
+++ b/docs/DOMAIN_MAP.md
@@ -1,14 +1,16 @@
-# DOMAIN_MAP
+# Domain Map
 
 **Last updated:** 2026-04-23  
 **Owner:** Architecture / Docs  
-**Scope:** Mythic Vibe CLI repository
+**Scope:** Entire repository
+
+This map is the routing law for where code and docs belong.
 
 ---
 
-## 1) Purpose
+## 1) Why this exists
 
-This map defines where capabilities belong, which domains are active vs archival, and which dependencies are forbidden. Use it as the routing law before adding new code.
+In a multi-project monorepo, contributors can unintentionally modify dormant or vendor areas while trying to ship active product behavior. This document prevents that drift by defining ownership and forbidden dependencies.
 
 ---
 
@@ -16,14 +18,14 @@ This map defines where capabilities belong, which domains are active vs archival
 
 | Domain | Primary paths | Status | Owns | Must not own |
 |---|---|---|---|---|
-| Product CLI | `mythic_vibe_cli/`, `tests/`, `pyproject.toml` | **Active** | CLI commands, workflow loop, config resolution, codex packet generation, method sync | Research corpus, vendor forks, experimental runtimes |
-| Governance Docs | `docs/`, `ARCHITECTURE.md`, `DOMAIN_MAP.md`, `DATA_FLOW.md`, `DEPENDENCIES.md`, `INVENTORY.md` | **Active** | Architecture records, operational rules, contributor orientation | Runtime implementation code |
-| Skills & Agent Modes | `skills/`, `.claude/`, `.roo/` | **Active** | Reusable agent workflows, persona definitions, structured execution patterns | Product runtime logic |
-| Legacy Runtime Cluster | `ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`, `imports/norsesaga/` | Dormant / fragmented | Historical and experimental runtime components | New product-critical features without ADR |
-| Thoughtform Island | `mindspark_thoughtform/` | Dormant / self-contained | Cognitive pipeline experiments | CLI production dependencies |
-| WYRD Protocol Island | `WYRD-Protocol-World-Yielding-Real-time-Data-AI-world-model/` | Dormant / self-contained | Protocol/world-model research and SDKs | CLI production dependencies |
-| Vendor Mirrors | `ollama/`, `whisper/`, `chatterbox/` | Vendor snapshots | Upstream reference code | Direct import targets for product CLI |
-| Research Corpus | `research_data/`, `docs/research/`, `docs/specs/` | Informational | Theory, studies, exploratory design artifacts | Authoritative runtime behavior |
+| Product CLI | `mythic_vibe_cli/`, `tests/`, packaging files | **Active** | Command contracts, workflow lifecycle, config, prompt packet generation, method sync | Vendor mirrors, research corpus, dormant runtime islands |
+| Governance Docs | `docs/`, root architecture/governance docs | **Active** | Architecture records, operating rules, contributor orientation | Runtime implementation logic |
+| Skills & Agent Modes | `skills/`, `.claude/`, `.roo/` | **Active** | Reusable workflows/personas and execution guidance | Product runtime code |
+| Legacy Runtime Cluster | `ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`, `imports/norsesaga/` | Dormant/fragmented | Historical experiments and partial runtime systems | New product-critical features without explicit architecture decision |
+| Thoughtform Island | `mindspark_thoughtform/` | Dormant/self-contained | Research implementation experiments | CLI production dependencies |
+| WYRD Protocol Island | `WYRD-Protocol-World-Yielding-Real-time-Data-AI-world-model/` | Dormant/self-contained | Protocol/world-model exploration | CLI production dependencies |
+| Vendor Mirrors | `ollama/`, `whisper/`, `chatterbox/` | Snapshot/reference | Upstream code mirrors | Direct import targets in active CLI |
+| Research Corpus | `research_data/`, `docs/research/`, `docs/specs/` | Informational | Theory/spec references | Authoritative runtime behavior |
 
 ---
 
@@ -32,57 +34,57 @@ This map defines where capabilities belong, which domains are active vs archival
 ### Product CLI (`mythic_vibe_cli/*`)
 
 Allowed:
-- Python stdlib + declared package dependencies.
+- Python stdlib and declared package dependencies.
 - Internal imports within `mythic_vibe_cli/`.
-- File-system interaction with scaffold targets (`docs/`, `tasks/`, `mythic/`).
-- Explicit network access isolated to sync/import flows.
+- File IO for project scaffolds and operational artifacts.
+- Explicit network access in sync/import paths.
 
 Forbidden:
-- Imports from `ai/`, `core/`, `systems/`, `yggdrasil/`, `imports/norsesaga/`.
-- Imports from `mindspark_thoughtform/` or `WYRD-Protocol-.../`.
-- Imports from vendor mirrors (`ollama/`, `whisper/`, `chatterbox/`).
+- Imports from dormant runtime clusters.
+- Imports from Thoughtform/WYRD islands.
+- Imports from vendor mirrors.
 
-### Docs/skills domains
+### Docs and skills domains
 
 Allowed:
-- Referencing stable repository paths and contract files.
+- References to stable repository-relative paths.
 
 Forbidden:
-- Embedding secrets, local absolute machine paths, or hidden production assumptions.
+- Secrets, machine-specific absolute paths, undocumented production assumptions.
 
 ---
 
-## 4) Active product ownership map
+## 4) Ownership map for active CLI
 
-| Subdomain | File owner |
+| Subdomain | Canonical owner |
 |---|---|
-| Command surface and argument contracts | `mythic_vibe_cli/cli.py` |
-| Workflow lifecycle, scaffold generation, and status transitions | `mythic_vibe_cli/workflow.py` |
-| Config layering, coercion, and env/file precedence | `mythic_vibe_cli/config.py` |
-| Codex/ChatGPT packet synthesis and compaction | `mythic_vibe_cli/codex_bridge.py` |
-| Mythic method syncing/import behavior | `mythic_vibe_cli/mythic_data.py` |
+| Command surface and args | `mythic_vibe_cli/cli.py` |
+| Workflow lifecycle and phase transitions | `mythic_vibe_cli/workflow.py` |
+| Config precedence and coercion | `mythic_vibe_cli/config.py` |
+| Prompt packet synthesis and compaction | `mythic_vibe_cli/codex_bridge.py` |
+| Method sync/import/caching | `mythic_vibe_cli/mythic_data.py` |
 
 ---
 
 ## 5) Routing rules for new work
 
-- New CLI commands or aliases → `mythic_vibe_cli/cli.py`
-- New phase/state behavior → `mythic_vibe_cli/workflow.py`
-- New config knobs or precedence rules → `mythic_vibe_cli/config.py`
-- New packet sections/format logic → `mythic_vibe_cli/codex_bridge.py`
-- New method sync providers/parsers → `mythic_vibe_cli/mythic_data.py`
-- New architecture governance text → `docs/` + root architecture pack
-- New persona/workflow skill → `skills/<skill-name>/`
+- New command or alias -> `mythic_vibe_cli/cli.py`
+- New workflow phase/state behavior -> `mythic_vibe_cli/workflow.py`
+- New configuration setting -> `mythic_vibe_cli/config.py`
+- New packet section/formatting -> `mythic_vibe_cli/codex_bridge.py`
+- New sync provider/parser -> `mythic_vibe_cli/mythic_data.py`
+- New governance documentation -> `docs/` + corresponding root records
+- New agent workflow/skill -> `skills/<skill-name>/`
 
 ---
 
-## 6) Boundary-compliant change checklist
+## 6) Boundary compliance checklist
 
 A change is compliant only if all are true:
 
-1. It stays inside domain-owned paths.
+1. It stays inside the proper owning domain.
 2. It introduces no forbidden cross-domain import.
-3. It updates this map (and related architecture docs) when ownership shifts.
-4. It includes verification commands for touched domains.
+3. It updates governance docs when ownership/boundaries shift.
+4. It includes verification commands relevant to changed domains.
 
-If any condition fails, treat the change as architectural drift and correct it before merge.
+If any check fails, treat the change as architectural drift and fix before merge.

--- a/docs/SYSTEM_VISION.md
+++ b/docs/SYSTEM_VISION.md
@@ -1,96 +1,121 @@
-# SYSTEM VISION
+# System Vision
 
 ## Purpose
 
-Mythic Vibe CLI exists to make disciplined software creation accessible to ordinary builders by turning architectural intent into repeatable execution loops.
+Mythic Vibe CLI exists to make disciplined software creation accessible to ordinary builders by turning intent into repeatable execution loops.
 
-The system should feel like a trusted co-navigator: structured enough to prevent drift, flexible enough to preserve creativity, and explicit enough to keep teams aligned over time.
+The system should feel like a dependable co-navigator: structured enough to prevent drift, flexible enough to preserve creativity, and explicit enough to maintain team alignment over time.
+
+---
 
 ## North Star
 
-Enable any individual or small team to move from idea to resilient implementation through a clear, phase-based method:
+Enable individuals and small teams to move from idea to resilient implementation through a transparent phase method:
 
 `intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
 
-Success means users can repeatedly ship coherent work with less confusion, fewer rewrites, and better documentation continuity.
+Success means users can repeatedly ship coherent outcomes with fewer rewrites, clearer decisions, and better continuity across sessions.
 
-## Product Promises
+---
 
-1. **Architecture-first by default**  
-   The CLI should always steer users to define goals, constraints, and design decisions before coding.
+## Product promises
 
-2. **Beginner-friendly, expert-capable**  
-   Core workflows must remain understandable for new users while still supporting advanced users who want speed and depth.
+1. **Architecture-first by default**
+   Encourage goal/constraint/design clarity before implementation.
 
-3. **Traceable progress**  
-   Every major action should leave a durable artifact (docs, plans, logs, status updates) so decisions can be audited and continued.
+2. **Beginner-friendly, expert-capable**
+   Keep the default loop understandable while supporting advanced depth.
 
-4. **Low-friction human + AI collaboration**  
-   The system should support practical copy/paste collaboration with LLMs and preserve context through structured prompt packets.
+3. **Traceable progress**
+   Each meaningful action leaves durable artifacts for future recovery.
 
-5. **Method fidelity without rigidity**  
-   The CLI should enforce healthy defaults while allowing intentional adaptation for project-specific realities.
+4. **Practical human + AI collaboration**
+   Structured prompt packets should improve quality without obscuring method.
 
-## Scope of the System
+5. **Method fidelity without rigidity**
+   Enforce healthy defaults while permitting intentional adaptation.
+
+---
+
+## Scope
 
 ### In scope
-- Project initialization with Mythic-aligned structure.
+
+- Project initialization and method-aligned scaffolding.
 - Workflow commands for planning, check-ins, diagnostics, and status.
-- Documentation scaffolding and method reinforcement.
-- Prompt packet generation and response logging for AI-assisted development.
+- Documentation scaffolding and process reinforcement.
+- Prompt packet generation and response logging for AI collaboration.
 
 ### Out of scope
+
 - Replacing engineering judgment.
-- Fully autonomous code generation without human review.
-- Locking users into one model provider or one coding style.
+- Fully autonomous implementation without review.
+- Vendor lock-in to a single model/service/provider.
 
-## System Design Principles
+---
 
-- **Clarity over cleverness:** command behavior should be legible and predictable.
-- **Artifacts over memory:** decisions belong in files, not in private context.
-- **Small loops, fast feedback:** prefer incremental progress with verification checkpoints.
-- **Stable defaults, configurable edges:** beginner-safe defaults with layered config for power users.
-- **Transparency over magic:** users should understand why the tool suggests or enforces a step.
+## Design principles
 
-## User Experience Vision
+- **Clarity over cleverness:** command behavior should be legible.
+- **Artifacts over memory:** key decisions belong in files.
+- **Small loops, fast feedback:** favor incremental progress + verification.
+- **Stable defaults, configurable edges:** safe defaults with power-user control.
+- **Transparency over magic:** explain why the tool guides/enforces steps.
+
+---
+
+## UX expectations
 
 A user should be able to:
-1. Initialize or adopt a project rapidly.
-2. See what phase they are in and what “done” means for that phase.
-3. Generate AI collaboration context without leaking method structure.
-4. Record progress in seconds and return days later without losing thread.
-5. Diagnose project health quickly when momentum drops.
 
-## Quality Bar
+1. Initialize or adopt a project quickly.
+2. See current phase and phase-completion criteria.
+3. Generate high-signal AI context without losing method structure.
+4. Resume work days later using durable artifacts.
+5. Diagnose project health rapidly when momentum stalls.
+
+---
+
+## Quality bar
 
 A high-quality Mythic Vibe CLI interaction is:
-- **Coherent:** commands reinforce a single mental model.
+
+- **Coherent:** behavior reinforces one mental model.
 - **Recoverable:** state can be inspected and repaired.
-- **Documented:** decisions and outcomes are captured.
+- **Documented:** rationale and outcomes are captured.
 - **Composable:** workflows chain cleanly across phases.
-- **Trustworthy:** diagnostics and status reflect reality.
+- **Trustworthy:** diagnostics reflect actual project state.
 
-## Evolution Path
+---
 
-Near-term evolution should prioritize:
-1. Better phase guidance and error messages.
-2. Stronger diagnostics and remediation hints.
+## Evolution path
+
+### Near-term priorities
+
+1. Clearer phase guidance and error messaging.
+2. Better diagnostics with concrete remediation.
 3. Higher-signal prompt packet composition.
-4. Clearer project-level governance docs and templates.
+4. Stronger governance templates and contributor onboarding.
 
-Long-term evolution may include:
+### Long-term opportunities
+
 - Multi-agent orchestration patterns.
-- Richer retrieval and memory integrations.
-- Extended ritual command ecosystem with explicit safety rails.
+- Richer memory/retrieval integrations.
+- Expanded ritual command ecosystem with explicit guardrails.
 
-## Anti-Goals (Guardrails)
+---
+
+## Anti-goals
 
 The system should not become:
-- A black-box agent that hides decisions.
-- A brittle bureaucracy that blocks momentum.
-- A style-policing engine detached from project outcomes.
-- A vendor-locked workflow tied to one external service.
 
-## Final Vision Statement
+- A black-box agent that hides decisions,
+- A process bureaucracy that blocks delivery,
+- A style-policing layer detached from outcomes,
+- A workflow hard-locked to one external vendor.
 
-Mythic Vibe CLI is a practical engineering compass: a toolchain that helps humans and AI build software with stronger intent, clearer structure, and durable continuity from first idea to maintained system.
+---
+
+## Final vision statement
+
+Mythic Vibe CLI is an engineering compass: a toolchain that helps humans and AI build software with stronger intent, clearer structure, and durable continuity from first idea to maintained system.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,178 +1,143 @@
 # API Reference
 
-Core public API for integrating ThoughtForge into your application.
+This document describes the primary integration surfaces for the active **Mythic Vibe CLI** product path.
+
+> Note: This repository contains historical and research artifacts. Treat this file as authoritative only for active CLI-facing APIs/workflows.
 
 ---
 
-## ThoughtForgeCore
+## 1) CLI entrypoint
 
-The main entry point. Handles the full `think()` pipeline.
+### Module execution
+
+```bash
+python -m mythic_vibe_cli.cli --help
+```
+
+### Installed command (environment-dependent)
+
+```bash
+mythic --help
+```
+
+If both are available, prefer the installed command for daily use and module execution for debugging.
+
+---
+
+## 2) Core modules and contracts
+
+### `mythic_vibe_cli.cli`
+
+Responsibility:
+- command surface,
+- argument parsing,
+- dispatch to workflow/config/data subsystems.
+
+Contract guidance:
+- Keep command names and flags stable once published.
+- Add aliases only when they do not create ambiguity.
+
+### `mythic_vibe_cli.workflow`
+
+Responsibility:
+- orchestrates phase loop,
+- manages artifact creation/updates,
+- supports status/check-in behavior.
+
+Contract guidance:
+- Preserve deterministic phase ordering unless explicitly versioned.
+- Emit actionable errors with remediation hints.
+
+### `mythic_vibe_cli.config`
+
+Responsibility:
+- resolve layered configuration from defaults + files + env.
+
+Contract guidance:
+- Document precedence in code comments and user docs.
+- Avoid side effects during parse/load.
+
+### `mythic_vibe_cli.codex_bridge`
+
+Responsibility:
+- compose prompt/context packets,
+- apply compaction and budget logic.
+
+Contract guidance:
+- Prefer explicit section boundaries.
+- Keep packet outputs inspectable and reproducible.
+
+### `mythic_vibe_cli.mythic_data`
+
+Responsibility:
+- sync/import/cache method data from supported providers.
+
+Contract guidance:
+- Isolate network concerns here.
+- Avoid absorbing orchestration responsibilities.
+
+---
+
+## 3) Artifact interface (filesystem contract)
+
+CLI workflows interact with project artifacts such as:
+
+- `docs/` (governance and architecture notes)
+- `tasks/` (execution plans/checklists)
+- `mythic/` (method/runtime state)
+- `DEVLOG.md` and related operational logs
+- local cache/state files (for example `weave.db` where applicable)
+
+These are part of the product contract: if you rename or relocate them, update docs and migration behavior together.
+
+---
+
+## 4) Backward compatibility guidance
+
+When changing CLI/API behavior:
+
+1. Prefer additive changes over breaking renames.
+2. If breaking, provide migration notes in the same PR.
+3. Update `docs/quickstart.md` and architecture docs concurrently.
+4. Include verification commands proving new behavior.
+
+---
+
+## 5) Example integration pattern (subprocess)
 
 ```python
-from thoughtforge.cognition.core import ThoughtForgeCore
-from pathlib import Path
+import subprocess
 
-core = ThoughtForgeCore(
-    model_path=Path("/models/mistral-7b-q4.gguf"),   # optional
-    memory_dir=Path("~/.local/share/thoughtforge/memory"),
-    db_path=Path("~/.local/share/thoughtforge/knowledge/thoughtforge.db"),
+result = subprocess.run(
+    ["python", "-m", "mythic_vibe_cli.cli", "--help"],
+    check=True,
+    capture_output=True,
+    text=True,
 )
-
-result = core.think("What is Yggdrasil?")
-print(result.text)
-print(result.citations)     # ["Q42240"]
-print(result.enforcement_passed)   # True/False
+print(result.stdout)
 ```
 
-### `ThoughtForgeCore(model_path, memory_dir, db_path)`
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `model_path` | `Path \| None` | `None` | Path to GGUF model. `None` = knowledge-only mode. |
-| `memory_dir` | `Path \| None` | Auto | Directory for episodic memory, preferences, etc. |
-| `db_path` | `Path \| None` | Auto | Path to SQLite knowledge DB. |
-
-### `think(user_text, retrieval_path=None, num_drafts=None) → FinalResponseRecord`
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `user_text` | `str` | — | User query text. |
-| `retrieval_path` | `"sql" \| "vector" \| "hybrid" \| None` | Auto | Override retrieval path. |
-| `num_drafts` | `int \| None` | Profile default | Override draft count. |
+Use subprocess execution when integrating from external tooling to keep process boundaries explicit.
 
 ---
 
-## FinalResponseRecord
-
-Returned by `think()`. All fields are always populated.
+## 6) Example integration pattern (in-repo module import)
 
 ```python
-@dataclass
-class FinalResponseRecord:
-    turn_id: str               # UUID for this turn
-    text: str                  # final response text
-    citations: list[str]       # QID strings cited in text (e.g. ["Q42240"])
-    scores: CandidateScores    # composite, quality_tier, etc.
-    token_count: int           # estimated tokens in response
-    enforcement_passed: bool   # True if EnforcementGate passed
-    enforcement_notes: str     # notes if enforcement review needed
-    salvage_path: str          # "best_draft" | "refine_pass_1" | "knowledge_only"
-    retrieval_confidence: float
-    mode: str                  # generation mode used
+# Pseudocode pattern: import only stable module surfaces.
+from mythic_vibe_cli import cli, workflow, config
+
+# Build your wrapper around documented commands/workflows
+# rather than reaching into private helper internals.
 ```
 
-### Quality Tiers (`scores.quality_tier`)
-
-| Tier | Composite Score | Meaning |
-|---|---|---|
-| `excellent` | ≥ 0.85 | Strong citations + adequate length |
-| `good` | ≥ 0.65 | Solid response with some citations |
-| `adequate` | ≥ 0.45 | Acceptable but could improve |
-| `poor` | < 0.45 | Weak — enforcement likely flagged |
+Prefer public, stable functions and avoid coupling to private helpers.
 
 ---
 
-## FragmentSalvage
+## 7) Change checklist for API-affecting PRs
 
-```python
-from thoughtforge.refinement.salvage import FragmentSalvage
-
-salvage = FragmentSalvage()
-result = salvage.forge(candidates, bundle)
-
-# result.salvage_path: "best_draft" | "refine_pass_1" | "empty"
-# result.confidence: 0.0 – 1.0
-# result.citations: list of QID strings
-```
-
----
-
-## EnforcementGate
-
-```python
-from thoughtforge.refinement.enforcement import EnforcementGate
-
-gate = EnforcementGate()
-result = gate.check(text, citations, retrieved_qids)
-
-# result.passed: bool
-# result.status: "pass" | "review"
-# result.citation_check, result.length_check, result.genericness_check: bool
-# result.notes: str (empty if all pass)
-```
-
----
-
-## EdgeSubsetBuilder
-
-```python
-from thoughtforge.etl.subset import EdgeSubsetBuilder
-from pathlib import Path
-
-builder = EdgeSubsetBuilder()
-result = builder.build(
-    source_db=Path("data/thoughtforge.db"),
-    output_path=Path("data/thoughtforge_pi_zero.db"),
-    profile_id="pi_zero",       # uses 50K entity limit
-    max_entities=30_000,        # optional override
-)
-
-print(result.entities_copied)
-print(result.size_mb)
-print(result.success)
-```
-
----
-
-## OnnxExporter / ONNXEmbedder
-
-```python
-from thoughtforge.inference.onnx_export import OnnxExporter, ONNXEmbedder
-from pathlib import Path
-
-# Export (requires optimum or torch)
-exporter = OnnxExporter()
-result = exporter.export_embedder(
-    model_name="sentence-transformers/all-MiniLM-L6-v2",
-    output_dir=Path("models/onnx/all-MiniLM-L6-v2"),
-    quantize=True,   # produce int8 model
-)
-
-# Embed at runtime (requires onnxruntime)
-embedder = ONNXEmbedder(result.output_dir)
-vectors = embedder.encode(["Yggdrasil", "Midgard"])
-# vectors.shape == (2, 384)
-```
-
----
-
-## ProfileBenchmark
-
-```python
-from benchmarks.benchmark_profiles import ProfileBenchmark
-
-result = ProfileBenchmark().run("desktop_cpu")
-print(result.summary())
-print(result.citation_accuracy)       # 0.0–1.0
-print(result.enforcement_pass_rate)   # 0.0–1.0
-print(result.avg_latency_ms)          # milliseconds
-```
-
----
-
-## PersonaConsistencyScorer
-
-```python
-from benchmarks.persona_consistency import PersonaConsistencyScorer
-
-responses = [r.text for r in turn_results]
-scorer = PersonaConsistencyScorer()
-result = scorer.score(responses)
-
-print(result.consistency_score)   # 0.0–1.0 (target ≥ 0.75)
-print(result.passes)              # bool
-print(result.summary())
-
-# Generate markdown report
-report = PersonaConsistencyScorer.generate_report(result, "persona_report.md")
-```
+- [ ] CLI help/output updated where relevant
+- [ ] Docs updated (`quickstart`, `api`, and architecture/domain docs as needed)
+- [ ] Tests/checks run and recorded
+- [ ] Boundary rules validated (no forbidden cross-island imports)

--- a/docs/hardware_profiles.md
+++ b/docs/hardware_profiles.md
@@ -1,170 +1,110 @@
 # Hardware Profiles
 
-ThoughtForge auto-detects your hardware and selects the appropriate profile.
-You can override manually with `--profile` or `-profile`.
+This guide maps typical machine classes to practical operating profiles for local AI-assisted workflows in this repository ecosystem.
+
+> Use this as planning guidance. Actual performance depends on model choice, quantization, context length, and concurrent workload.
 
 ---
 
-## Profile Overview
+## 1) Profile quick matrix
 
-| Profile | RAM | VRAM | Model Size | Quantization | Context | Draft Count |
-|---|---|---|---|---|---|---|
-| `phone_low` | 2 GB | — | 1.1B (TinyLlama) | Q2_K | 512 tokens | 2 |
-| `pi_zero` | 512 MB | — | 1B subset | Q2_K ultra | 256 tokens | 1 |
-| `pi_5` | 4 GB | — | 1B–3B | Q4_K_M | 1024 tokens | 2 |
-| `desktop_cpu` | 8 GB+ | — | 3B–7B | Q4_K_M / Q8 | 2048 tokens | 3 |
-| `desktop_gpu` | — | 8–16 GB | 7B–13B | Q8 / fp16 | 4096 tokens | 3 |
-| `server_gpu` | — | 24 GB+ | 30B–70B | fp16 / bf16 | 8192 tokens | 4 |
-
----
-
-## Profile Details
-
-### `phone_low` — Smartphones
-
-**Target:** Android (Termux), iOS (MLC LLM), low-power ARM devices
-
-```json
-{
-  "hardware": { "ram_gb": 2, "cpu_arch": ["arm64", "armv8"] },
-  "model": { "max_params_b": 1.1, "quantization": "q2_k", "token_budget_per_turn": 180 },
-  "deployment": { "platforms": ["android", "ios"], "runtime": ["termux", "mlc-llm"], "onnx_export": true }
-}
-```
-
-**Recommended models:**
-- `TinyLlama-1.1B-Chat-v1.0.Q2_K.gguf` (~500 MB)
-- `Granite-1B-Instruct.Q3_K_S.gguf` (~600 MB)
-
-**Install:**
-```bash
-./scripts/install_termux.sh --profile phone_low --onnx
-```
+| Profile | RAM | VRAM | Typical model band | Suggested context budget | Suggested draft count | Best use case |
+|---|---:|---:|---|---:|---:|---|
+| `phone_low` | ~2 GB | — | 1B class (aggressively quantized) | 256–512 | 1–2 | mobile experimentation, lightweight prompts |
+| `pi_zero` | ~0.5 GB | — | 1B subset / knowledge-only | 128–256 | 1 | ultra-constrained edge and kiosk-style automation |
+| `pi_5` | ~4 GB | — | 1B–3B | 512–1024 | 1–2 | low-power local assistant workflows |
+| `desktop_cpu` | 8+ GB | — | 3B–7B | 1024–2048 | 2–3 | general daily development on CPU |
+| `desktop_gpu` | 16+ GB RAM | 8–16 GB | 7B–13B | 2048–4096 | 2–3 | high-throughput local development |
+| `server_gpu` | 64+ GB RAM | 24+ GB | 30B+ or multi-model serving | 4096–8192 | 3–4 | team/shared inference and deep context workloads |
 
 ---
 
-### `pi_zero` — Raspberry Pi Zero 2W
+## 2) How to choose a profile
 
-**Target:** 512 MB RAM single-board computers. Ultra-constrained.
+Prioritize in this order:
 
-```json
-{
-  "hardware": { "ram_gb": 0.5, "cpu_arch": ["armv7l", "arm64"] },
-  "model": { "max_params_b": 1.1, "quantization": "q2_k", "token_budget_per_turn": 120 },
-  "deployment": { "platforms": ["linux-arm"], "onnx_export": true, "knowledge_subset": true }
-}
-```
-
-**Notes:**
-- Use `--subset` flag during Pi install to build reduced knowledge DB (50K entities)
-- Knowledge-only mode recommended — inference is very slow on Pi Zero
-- Increase swap to 1 GB before compiling llama-cpp-python
+1. **Stability first:** choose the profile that avoids swapping/OOM under expected load.
+2. **Latency target second:** reduce model size/context before increasing hardware complexity.
+3. **Quality tuning third:** increase draft count/context gradually after stability is proven.
 
 ---
 
-### `pi_5` — Raspberry Pi 4 / 5
+## 3) Practical recommendations by profile
 
-**Target:** 4 GB ARM board, optional Vulkan VideoCore VII (Pi 5)
+### `phone_low`
 
-```json
-{
-  "hardware": { "ram_gb": 4, "cpu_arch": ["arm64"] },
-  "model": { "max_params_b": 3, "quantization": "q4_k_m", "token_budget_per_turn": 200 },
-  "deployment": { "platforms": ["linux-arm"], "runtime": ["docker", "native"] }
-}
-```
+- Use short prompts and constrained output lengths.
+- Prefer quantized 1B-class models.
+- Keep background apps minimal to reduce OS memory pressure.
 
-**Recommended models:**
-- `Phi-3-mini-128k-instruct.Q4_K_M.gguf` (~2.2 GB)
-- `Gemma-2B-it.Q4_K_M.gguf` (~1.5 GB)
+### `pi_zero`
 
-**Install with Vulkan (Pi 5):**
-```bash
-./scripts/install_pi.sh --profile pi_5 --vulkan
-```
+- Treat this as knowledge-only or narrowly scoped inference.
+- Build reduced datasets/subsets where applicable.
+- Avoid large context windows and multi-draft generation.
 
----
+### `pi_5`
 
-### `desktop_cpu` — Desktop / Laptop (CPU)
+- Use compact models and moderate context.
+- Limit concurrent services while running local inference.
+- Consider lightweight batching only if thermals stay controlled.
 
-**Target:** 8–32 GB RAM, x86_64 or ARM64, no discrete GPU required.
+### `desktop_cpu`
 
-```json
-{
-  "hardware": { "ram_gb": 8, "inference_backend": "cpu" },
-  "model": { "max_params_b": 7, "quantization": "q4_k_m", "token_budget_per_turn": 220 }
-}
-```
+- Best balance for many contributors.
+- Prefer mid-size quantized models and 2–3 draft loops.
+- If latency is high, reduce context before changing profile.
 
-**Recommended models:**
-- `Mistral-7B-Instruct-v0.3.Q4_K_M.gguf` (~4.1 GB)
-- `LLaMA-3-8B-Instruct.Q4_K_M.gguf` (~4.6 GB)
-- `Phi-3-mini-128k-instruct.Q8_0.gguf` (~4.0 GB)
+### `desktop_gpu`
 
----
+- Strong default for advanced local workflows.
+- Monitor VRAM fragmentation when switching models repeatedly.
+- Keep fallback CPU profile available for reliability.
 
-### `desktop_gpu` — Desktop / Workstation GPU
+### `server_gpu`
 
-**Target:** NVIDIA (CUDA), AMD (ROCm), Intel Arc (Vulkan). 8–16 GB VRAM.
-
-```json
-{
-  "hardware": { "vram_gb": 12, "inference_backend": "cuda" },
-  "model": { "max_params_b": 13, "quantization": "q8_0", "token_budget_per_turn": 240 }
-}
-```
-
-**Recommended models:**
-- `LLaMA-3-8B-Instruct.Q8_0.gguf` (8 GB VRAM)
-- `Mistral-7B-Instruct-v0.3.fp16.gguf` (14 GB VRAM — requires 16 GB card)
-
-**GPU backend auto-detection priority:** CUDA → ROCm → Vulkan → Metal → CPU
+- Use for heavy-context or team-serving scenarios.
+- Enforce resource quotas and concurrency limits.
+- Document model routing and failover behavior.
 
 ---
 
-### `server_gpu` — Server / Cloud GPU
+## 4) Override strategy
 
-**Target:** 24 GB+ VRAM. A100, H100, RTX 3090+, RTX 4090.
+When profile auto-selection is available, it should be considered a baseline. Override only when you have measured reason to do so.
 
-```json
-{
-  "hardware": { "vram_gb": 24, "inference_backend": "cuda" },
-  "model": { "max_params_b": 70, "quantization": "fp16", "token_budget_per_turn": 250 },
-  "deployment": { "multi_gpu": true }
-}
-```
+Common override triggers:
 
-**Recommended models:**
-- `LLaMA-3-70B-Instruct.fp16` (requires 140 GB VRAM across 2× A100 80GB)
-- `Mixtral-8x7B-Instruct.Q4_K_M.gguf` (24 GB single GPU)
-- `LLaMA-3-70B-Instruct.Q4_K_M.gguf` (40 GB — 2× 24GB)
+- predictable OOM events,
+- unacceptable latency for your loop,
+- specific model constraints requiring alternate quantization.
 
 ---
 
-## Overriding the Profile
+## 5) Custom profile governance
 
-```bash
-# CLI
-python run_thoughtforge.py --profile pi_5
+If you add custom profiles in code/config:
 
-# Python API
-from thoughtforge.cognition.core import ThoughtForgeCore
-core = ThoughtForgeCore(model_path=None)  # auto-detect
-```
+- Include explicit memory and context ceilings.
+- Document expected model band and fallback behavior.
+- Add a short benchmark note (latency + stability observation).
+- Keep naming stable and human-readable.
 
-## Manual Profile Tuning
+---
 
-Profiles are JSON files in `hardware_profiles/`. You can add a custom profile:
+## 6) Operational warning signs
 
-```json
-{
-  "profile_id": "my_workstation",
-  "display_name": "My Workstation",
-  "hardware": { "ram_gb": 32, "vram_gb": 24, "inference_backend": "cuda" },
-  "model": { "max_params_b": 13, "quantization": "q8_0", "token_budget_per_turn": 240 },
-  "memory": { "episodic_store_cap_soft": 2048, "episodic_store_cap_hard": 4096 },
-  "retrieval": { "sql_max_results": 15, "vector_top_k": 10 },
-  "generation": { "max_response_tokens": 500, "temperature": 0.7, "max_refinement_passes": 2 },
-  "deployment": { "platforms": ["linux", "windows"], "runtime": ["native"], "onnx_export": false }
-}
-```
+Re-tune profile selection when you observe:
+
+- repeated OOM/swap spikes,
+- severe p95 latency regressions,
+- unstable generation quality from over-aggressive quantization,
+- thermal throttling on edge devices.
+
+---
+
+## 7) Related docs
+
+- [Quickstart](quickstart.md)
+- [API Reference](api.md)
+- [Architecture](ARCHITECTURE.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,70 +1,77 @@
-# MindSpark: ThoughtForge
+# Mythic Vibe CLI Documentation Hub
 
-**Universal cognitive enhancement layer for AI models of any size.**
+Welcome to the canonical documentation hub for **Mythic Vibe CLI**, a method-driven command-line tool for building software through explicit engineering phases.
 
-From a 1B TinyLlama on a Pi Zero to a 70B LLaMA on a server — ThoughtForge
-gives any model depth, presence, consistency, and verifiable knowledge grounding.
-
-It is not a model. It is the forge that makes any model sharper.
+> If you are new, start with **Quickstart**. If you are contributing, read **Architecture** and **Domain Map** next.
 
 ---
 
-## Core Pillars
+## What this project is
 
-| Pillar | What It Does |
-|---|---|
-| **Sovereign Local RAG** | Full offline knowledge base — Wikidata, ConceptNet, GeoNames, built-in reference. Zero internet at runtime. |
-| **TurboQuant Inference** | Universal hardware scaling: 2-bit phone → fp16 server. Auto-detects hardware profile. |
-| **Cognition Scaffolds** | Deterministic YAML steering objects: goal, tone, focus, avoid, depth, fact block. |
-| **Fragment Salvage** | Multi-draft generation → sentence-level scoring → intelligent reassembly. No judge model required. |
-| **Memory-Enforced Loop** | Cite-or-explain mandatory enforcement. Every response grounded in retrieved knowledge. |
+Mythic Vibe CLI helps you move from idea to implementation with a repeatable workflow:
+
+`intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
+
+Instead of relying on implicit memory, the CLI writes decisions into durable artifacts so you can pause, resume, and collaborate with less confusion.
 
 ---
 
-## Hardware Support
+## Documentation map
 
-| Profile | RAM | Model Size | Use Case |
-|---|---|---|---|
-| `phone_low` | 2 GB | 1B (TinyLlama) | Android/Termux, low-power |
-| `pi_zero` | 512 MB | 1B subset | Raspberry Pi Zero 2W |
-| `pi_5` | 4 GB | 1B–3B | Raspberry Pi 4/5 |
-| `desktop_cpu` | 8 GB+ | 3B–7B | Desktop/laptop, CPU only |
-| `desktop_gpu` | 8–16 GB VRAM | 7B–13B | Gaming GPU, workstation |
-| `server_gpu` | 24 GB+ VRAM | 30B–70B | Server, cloud GPU |
+### Start here
 
----
+1. **[Quickstart](quickstart.md)**
+   Install, initialize, and run your first project loop.
+2. **[System Vision](SYSTEM_VISION.md)**
+   Product intent, quality bar, and long-term direction.
+3. **[Architecture](ARCHITECTURE.md)**
+   Active runtime boundaries and dependency direction.
 
-## Quickstart
+### Governance and boundaries
 
-```bash
-git clone https://github.com/hrabanazviking/MindSpark_ThoughtForge
-cd MindSpark_ThoughtForge
-
-# Linux/macOS
-chmod +x scripts/install_linux.sh && ./scripts/install_linux.sh
-
-# Windows (PowerShell)
-.\scripts\install_windows.ps1
-
-# Activate and build reference knowledge
-source .venv/bin/activate
-python forge_memory.py reference
-
-# Run (knowledge-only mode, no model required)
-python run_thoughtforge.py
-```
+- **[Domain Map](DOMAIN_MAP.md)** — source-of-truth ownership map for active vs dormant domains.
+- **[API Reference](api.md)** — public Python and CLI integration surfaces.
+- **[Hardware Profiles](hardware_profiles.md)** — deployment guidance for constrained and high-end machines.
 
 ---
 
-## Design Philosophy
+## Who this is for
 
-ThoughtForge is built on three principles:
+- **Solo builders** who need a reliable workflow, not just command sprawl.
+- **Small teams** who want traceable decisions and better handoffs.
+- **AI-assisted developers** who need structured context packets and method continuity.
 
-**Sovereignty** — No API keys. No cloud. No surveillance. Every component
-operates fully offline. Your knowledge, your compute, your data.
+---
 
-**Universality** — The same codebase runs on a phone and a server cluster.
-Hardware profiles adapt token budgets, quantization, and draft counts automatically.
+## Recommended reading paths
 
-**Verifiability** — Every response is grounded in retrieved knowledge with
-QID citations. The enforcement gate ensures nothing slips through unchecked.
+### Path A: New user (10–15 minutes)
+
+1. Read [Quickstart](quickstart.md)
+2. Run one full CLI loop
+3. Scan [System Vision](SYSTEM_VISION.md)
+
+### Path B: Contributor / maintainer (20–30 minutes)
+
+1. Read [Architecture](ARCHITECTURE.md)
+2. Read [Domain Map](DOMAIN_MAP.md)
+3. Review [API Reference](api.md)
+4. Verify boundaries before opening a PR
+
+---
+
+## Documentation standards
+
+When you update runtime behavior, update docs in the same PR:
+
+- **Behavior change** -> `api.md` and/or `quickstart.md`
+- **Boundary/ownership change** -> `ARCHITECTURE.md` and `DOMAIN_MAP.md`
+- **Product direction change** -> `SYSTEM_VISION.md`
+
+If docs and behavior diverge, treat it as a bug.
+
+---
+
+## Project status note
+
+This repository is a multi-project monorepo. The active product path is **`mythic_vibe_cli/`**. Other trees include research, vendor mirrors, and historical/runtime experiments that are not primary CLI execution paths.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,180 +1,94 @@
-# Quick Start
+# Quickstart
 
-Get ThoughtForge running in under 5 minutes.
+Get Mythic Vibe CLI running quickly and complete your first structured workflow loop.
 
 ---
 
-## Prerequisites
+## 1) Prerequisites
 
-- Python 3.10, 3.11, or 3.12
+- Python 3.10+
 - Git
-- 500 MB free disk space (for reference knowledge only)
-- A GGUF model file *(optional — knowledge-only mode works without one)*
+- A shell environment (bash, zsh, PowerShell, or equivalent)
+
+Optional but useful:
+- A virtual environment tool (`venv`, `uv`, or `conda`)
+- An editor with Python linting and formatting support
 
 ---
 
-## Installation
+## 2) Clone and set up
 
-=== "Linux"
+```bash
+git clone <your-fork-or-repo-url>
+cd Viking-Code-Mythic-Engineering-CLI-Vibe-Coding
+python -m venv .venv
+source .venv/bin/activate  # Windows PowerShell: .\.venv\Scripts\Activate.ps1
+pip install -e .
+```
 
-    ```bash
-    git clone https://github.com/hrabanazviking/MindSpark_ThoughtForge
-    cd MindSpark_ThoughtForge
-    chmod +x scripts/install_linux.sh
-    ./scripts/install_linux.sh --profile desktop_cpu
-    source .venv/bin/activate
-    ```
-
-=== "macOS"
-
-    ```bash
-    git clone https://github.com/hrabanazviking/MindSpark_ThoughtForge
-    cd MindSpark_ThoughtForge
-    chmod +x scripts/install_mac.sh
-    ./scripts/install_mac.sh --profile desktop_cpu
-    # Apple Silicon: add --metal for Metal GPU acceleration
-    source .venv/bin/activate
-    ```
-
-=== "Windows"
-
-    ```powershell
-    git clone https://github.com/hrabanazviking/MindSpark_ThoughtForge
-    cd MindSpark_ThoughtForge
-    Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
-    .\scripts\install_windows.ps1 -Profile desktop_cpu
-    .\.venv\Scripts\Activate.ps1
-    ```
-
-=== "Termux (Android)"
-
-    ```bash
-    git clone https://github.com/hrabanazviking/MindSpark_ThoughtForge
-    cd MindSpark_ThoughtForge
-    chmod +x scripts/install_termux.sh
-    ./scripts/install_termux.sh --profile phone_low
-    source .venv/bin/activate
-    ```
-
-=== "Raspberry Pi"
-
-    ```bash
-    git clone https://github.com/hrabanazviking/MindSpark_ThoughtForge
-    cd MindSpark_ThoughtForge
-    chmod +x scripts/install_pi.sh
-    ./scripts/install_pi.sh  # auto-detects Pi Zero vs Pi 5
-    source .venv/bin/activate
-    ```
-
-=== "Docker"
-
-    ```bash
-    git clone https://github.com/hrabanazviking/MindSpark_ThoughtForge
-    cd MindSpark_ThoughtForge
-    docker compose up thoughtforge-desktop
-    ```
+If editable install is not configured in your environment, install dependencies from the project’s packaging files and run the module directly.
 
 ---
 
-## Build the Knowledge Base
+## 3) Verify the CLI is available
 
-ThoughtForge uses an offline SQLite knowledge database. Start with the built-in
-reference data (fast — seconds to minutes):
-
-```bash
-python forge_memory.py reference
-```
-
-For full knowledge (requires Wikidata dump — 100 GB+, many hours):
+Run one of the following (depending on your setup):
 
 ```bash
-python forge_memory.py all
+mythic --help
+# or
+python -m mythic_vibe_cli.cli --help
 ```
 
-Check status:
-
-```bash
-python forge_memory.py status
-```
+You should see command help text and available workflow operations.
 
 ---
 
-## Run
+## 4) Initialize a working loop
 
-### Interactive REPL
+Use the CLI to initialize/adopt a project and enter the method loop:
 
-```bash
-python run_thoughtforge.py
-```
+`intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
 
-```
-MindSpark: ThoughtForge
-The forge is ready. Type 'exit' or 'quit' to leave.
-
-Forge> What is Yggdrasil?
-
-════════════════════════════════════════════════════════════════════════
-Yggdrasil is the immense sacred tree in Norse cosmology, connecting
-the nine worlds: Asgard, Midgard, Jotunheim, and six others...
-════════════════════════════════════════════════════════════════════════
-Citations   : Q42240
-Confidence  : 0.712  [good]
-Enforcement : PASS
-Tokens      : 87
-```
-
-### Single Query
-
-```bash
-python run_thoughtforge.py "What are the nine worlds?"
-```
-
-### With a GGUF Model
-
-```bash
-python run_thoughtforge.py --model /models/phi-3-mini-q4.gguf --profile desktop_cpu
-```
-
-### Debug Logging
-
-```bash
-python run_thoughtforge.py --debug "Who is Loki?"
-```
+At each phase, capture outputs in project artifacts (for example, docs and task notes) so the next session starts with context.
 
 ---
 
-## Knowledge-Only Mode
+## 5) Daily operating pattern (recommended)
 
-ThoughtForge works without a GGUF model — it assembles a knowledge summary
-from retrieved records. Ideal for Pi Zero, low-RAM devices, or testing:
+1. **Check current status** (what phase, what’s blocked, what’s next).
+2. **Run the next phase command**.
+3. **Record decisions and rationale** in artifacts.
+4. **Verify outcomes** with tests/checks.
+5. **Log reflection** so future sessions resume cleanly.
 
-```bash
-python run_thoughtforge.py  # no --model flag = knowledge-only mode
-```
-
----
-
-## Building an Edge Subset
-
-For Pi Zero or phone (< 1 GB knowledge DB):
-
-```bash
-python - <<'EOF'
-from pathlib import Path
-from thoughtforge.etl.subset import EdgeSubsetBuilder
-
-builder = EdgeSubsetBuilder()
-result = builder.build(
-    source_db=Path("data/thoughtforge.db"),
-    profile_id="pi_zero",        # 50K entities
-)
-print(f"Subset: {result.entities_copied} entities → {result.output_path}")
-EOF
-```
+This operating pattern is the fastest way to avoid drift and repeated rework.
 
 ---
 
-## Next Steps
+## 6) Troubleshooting
 
-- See [Hardware Profiles](hardware_profiles.md) for profile tuning
-- See [API Reference](api.md) for `ThoughtForgeCore` integration
+### CLI not found
+
+- Confirm virtual environment is active.
+- Re-run `pip install -e .`.
+- Fall back to `python -m mythic_vibe_cli.cli --help`.
+
+### Phase confusion or state mismatch
+
+- Inspect generated artifacts in `docs/`, `tasks/`, and `mythic/`.
+- Re-run the status/check command before making edits.
+
+### Import/boundary errors
+
+- Review [Architecture](ARCHITECTURE.md) and [Domain Map](DOMAIN_MAP.md).
+- Ensure runtime code changes stay in `mythic_vibe_cli/` unless an explicit architecture decision says otherwise.
+
+---
+
+## 7) Next reads
+
+- [System Vision](SYSTEM_VISION.md)
+- [Architecture](ARCHITECTURE.md)
+- [Domain Map](DOMAIN_MAP.md)
+- [API Reference](api.md)


### PR DESCRIPTION
### Motivation

- Clarify and centralize contributor and user-facing documentation for the active product path in this monorepo. 
- Make onboarding faster by providing a concise docs hub, clear quickstart, and recommended reading paths. 
- Reduce architectural drift by codifying ownership, dependency direction, and change protocol for `mythic_vibe_cli`. 
- Make hardware/profile guidance and API integration patterns actionable for common developer workflows.

### Description

- Reworked the documentation hub by replacing `docs/index.md` with a clear entrypoint, reading paths, and doc-update standards. 
- Expanded and simplified `docs/quickstart.md` to include practical clone/setup steps, verification checks, day-to-day operating cadence, and troubleshooting. 
- Refined `docs/ARCHITECTURE.md` and `docs/DOMAIN_MAP.md` to define active product boundaries, a one-way dependency direction law, ownership mapping, and a change protocol. 
- Polished `docs/SYSTEM_VISION.md`, `docs/api.md`, and `docs/hardware_profiles.md` to align product promises, CLI integration contracts, and profile-selection guidance with the active `mythic_vibe_cli` path, and removed stale/irrelevant ThoughtForge-specific content. 
- Minor cleanup: trimmed trailing whitespace in edited docs and kept artifact filenames/links consistent across files.

### Testing

- Ran `python -m mythic_vibe_cli.cli --help` to verify the documented CLI entrypoint and observed expected help output, which succeeded. 
- Ran `git diff --check` to validate whitespace and patch quality, and fixed trailing whitespace issues, which succeeded. 
- Performed a repo-level status and verified the modified docs were staged and committed; no runtime code changes were introduced and automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0f1c5a888325bb83ce32a15454f7)