### PR TITLE
docs: Scribe sweep — expand documentation, add CHANGELOG and canonical docs index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this repository's active product documentation and runtime-facing records are documented in this file.
+
+The format is inspired by Keep a Changelog and uses explicit dates for continuity.
+
+## [Unreleased]
+
+### Added
+
+- Added `docs/INDEX.md` as a canonical documentation navigation map and upkeep protocol.
+- Added first formal `CHANGELOG.md` to establish release-facing history discipline.
+
+### Changed
+
+- Expanded root `README.md` into a comprehensive operator and contributor guide.
+- Expanded `docs/index.md` with role-based reading paths and continuity references.
+- Expanded `docs/quickstart.md` with first-loop workflow, bridge usage, and troubleshooting.
+- Expanded `docs/ARCHITECTURE.md` with detailed component contracts, risk model, and review checklist.
+- Expanded `docs/DOMAIN_MAP.md` with stricter ownership/dependency boundaries and exception protocol.
+- Expanded `docs/api.md` with module contracts, compatibility policy, and integration examples.
+- Expanded `docs/SYSTEM_VISION.md` with mission detail, UX outcomes, and evolution horizons.
+- Updated `DEVLOG.md` with a dedicated session entry documenting the documentation sweep.
+
+## [2026-04-23]
+
+### Added
+
+- Documentation continuity framework upgrades for active product records.
+
+### Changed
+
+- Multiple core docs were rewritten and expanded for clarity, durability, and contributor onboarding.
+

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -88,3 +88,45 @@ The five upstream decisions named above are the only real open questions. Until 
 This is the second entry of the exploration phase. The register is laid; the decisions wait. Future entries will mark each integration motion as it is taken — one rune cut at a time.
 
 _May the record hold, and may the choices, when they come, be clear._
+
+## 2026-04-23 — Scribe Sweep: Documentation Polished and Expanded
+
+**Session:** Documentation consolidation and expansion pass.
+**Status:** Markdown-only change set across active docs. No runtime Python code modified.
+**Hands on the wheel:** Eirwyn Rúnblóm, The Scribe, performed a repository-facing continuity pass focused on the active Mythic Vibe CLI documentation suite.
+
+### What was changed
+
+This session executed a deep rewrite of the active documentation surfaces so they can function as durable, navigable, and contributor-safe records rather than short-form placeholders.
+
+Updated/added artifacts:
+
+- `README.md` — rewritten as a full operator/contributor guide with command orientation, repository posture notes, configuration model, and active-doc map.
+- `docs/INDEX.md` — newly added canonical navigation index and maintenance protocol.
+- `docs/index.md` — expanded user-facing hub with role-based reading paths.
+- `docs/quickstart.md` — expanded onboarding flow with bridge usage and troubleshooting depth.
+- `docs/ARCHITECTURE.md` — expanded component contracts, dependency law, risks, and architecture review checklist.
+- `docs/DOMAIN_MAP.md` — expanded ownership matrix, dependency boundaries, escalation path, and drift indicators.
+- `docs/api.md` — expanded command/module contracts, compatibility policy, and integration examples.
+- `docs/SYSTEM_VISION.md` — expanded mission, scope, design principles, UX expectations, and evolution horizons.
+- `CHANGELOG.md` — created release-facing history ledger.
+
+### Why it matters
+
+Before this pass, several docs were concise but shallow. The repository now has a clearer archival spine for:
+
+- onboarding new contributors,
+- preventing boundary drift in a large monorepo,
+- preserving release/session continuity,
+- and recovering intent after long pauses.
+
+### Continuity note
+
+This entry marks the beginning of explicit dual-record discipline:
+
+- `DEVLOG.md` for narrative chronology and rationale,
+- `CHANGELOG.md` for user/release-facing deltas.
+
+The two records should now evolve together when meaningful behavior or governance changes occur.
+
+_May the record hold._

--- a/README.md
+++ b/README.md
@@ -1,27 +1,78 @@
 # Mythic Vibe CLI
 
-An open-source vibe-coding CLI that **automatically follows the Mythic Engineering method** and is intentionally beginner-friendly.
+Mythic Vibe CLI is an open-source, method-first command-line tool for people who want to **ship software with continuity, architecture, and recoverable memory** rather than pure improvisation.
+
+It helps you run an explicit engineering loop:
+
+`intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
+
+The project is designed to be useful for first-time builders and still disciplined enough for maintainers who care about clean handoffs, repeatability, and artifact-driven collaboration.
 
 Canonical Mythic Engineering source:
 - https://github.com/hrabanazviking/Mythic-Engineering
 
-## Why this is better now
+---
 
-This now supports a **ChatGPT Plus ($20/mo) friendly Codex workflow**:
-- Generate a structured prompt packet from your local project context.
-- Paste it into ChatGPT/Codex.
-- Log the assistant output back into Mythic tracking.
-- Configure packet sizing + auto-compaction with global/local config files.
+## What changed in this documentation pass
 
-No API key is required for this copy/paste flow.
+This repository now includes a much deeper documentation suite for active product paths:
 
-## What this CLI enforces
+- Expanded operator-facing docs for setup, commands, architecture, API contracts, and governance.
+- Added a durable `CHANGELOG.md` with semantic structure and release notes discipline.
+- Added `docs/INDEX.md` as a stable navigation hub for docs consumers and contributors.
+- Updated `DEVLOG.md` with this documentation sweep so future sessions inherit context instead of guesswork.
 
-- Architecture-first scaffolding aligned to Mythic Engineering docs.
-- Required documentation starter files (`docs/`, `tasks/`, `MYTHIC_ENGINEERING.md`, `mythic/`).
-- A phase-based execution loop:
-  `intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
-- Progress tracking so you can keep collaborators in the loop with structured updates.
+If you are returning after a break, start at **`docs/INDEX.md`** first.
+
+---
+
+## Why Mythic Vibe CLI exists
+
+Many coding tools optimize for speed while underinvesting in continuity. Mythic Vibe CLI is opinionated about preserving reasoning in files so work can survive context loss, team turnover, and interrupted sessions.
+
+Core goals:
+
+1. **Reduce drift** between plans, code, and docs.
+2. **Improve AI-assisted execution** by packaging project context into explicit prompt packets.
+3. **Preserve intent and rationale** so later contributors can resume without reconstruction.
+4. **Keep the workflow beginner-safe** while still useful in complex projects.
+
+---
+
+## Core capabilities
+
+### 1) Method-first project initialization
+
+Scaffolds a project with opinionated documentation/task structure aligned to Mythic Engineering.
+
+### 2) Phase-oriented workflow operations
+
+Supports repeated movement through:
+- intent
+- constraints
+- architecture
+- plan
+- build
+- verify
+- reflect
+
+### 3) Prompt bridge for ChatGPT/Codex workflows
+
+Generates structured prompt packets from local context, for copy/paste usage with ChatGPT/Codex.
+
+### 4) Response logging for continuity
+
+Lets you persist summaries of AI output so context is retained in local artifacts.
+
+### 5) Diagnostics and status checks
+
+Surfaces missing files, invalid state, and method drift early.
+
+### 6) Configuration layering
+
+Supports user-level + project-level config plus environment overrides.
+
+---
 
 ## Install
 
@@ -29,13 +80,28 @@ No API key is required for this copy/paste flow.
 pip install -e .
 ```
 
-## Quick start (new project)
+### Prerequisites
+
+- Python 3.10+
+- Git
+- A shell environment (bash, zsh, PowerShell, etc.)
+
+Recommended:
+- A virtual environment (`venv`, `uv`, `conda`)
+- Linting/formatting tools in your editor
+
+---
+
+## Quick start
+
+Initialize a new project scaffold:
 
 ```bash
 mythic-vibe init --goal "Build a beginner-friendly TODO app" --noob
 ```
 
-This creates a Mythic-oriented scaffold including:
+This creates Mythic-oriented scaffolding such as:
+
 - `docs/PHILOSOPHY.md`
 - `docs/ARCHITECTURE.md`
 - `docs/DOMAIN_MAP.md`
@@ -47,43 +113,59 @@ This creates a Mythic-oriented scaffold including:
 - `mythic/status.json`
 - `MYTHIC_ENGINEERING.md`
 
-## Import full Mythic markdown corpus
+For complete onboarding, read `docs/quickstart.md`.
 
-To import **all `.md` files** from the canonical Mythic Engineering repo into your project:
+---
 
-```bash
-mythic-vibe import-md
-```
+## ChatGPT Plus / Codex bridge workflow
 
-By default this writes into `docs/mythic_source/` and creates an index file:
-- `docs/mythic_source/_import_index.json`
-
-Custom destination:
+1) Generate a context packet:
 
 ```bash
-mythic-vibe import-md --target docs/reference/mythic
+mythic-vibe codex-pack \
+  --phase plan \
+  --task "Implement the CLI command parser and file templates" \
+  --audience beginner
 ```
 
+2) Open `mythic/codex_prompt.md` and paste the `Prompt To Paste` section into ChatGPT/Codex.
 
-## Configuration (inspired by OpenCode-style layering)
+3) Log the assistant outcome:
 
-`mythic-vibe` resolves config from these files (low → high precedence):
-- `~/.mythic-vibe.json`
-- `$XDG_CONFIG_HOME/mythic-vibe/config.json`
-- `<project>/.mythic-vibe.json`
+```bash
+mythic-vibe codex-log --phase build --response "Implemented parser with subcommands and docs updates"
+```
 
-Environment variables override file values:
+4) Inspect status:
+
+```bash
+mythic-vibe status
+```
+
+---
+
+## Configuration model
+
+Config resolution precedence (low → high):
+
+1. `~/.mythic-vibe.json`
+2. `$XDG_CONFIG_HOME/mythic-vibe/config.json`
+3. `<project>/.mythic-vibe.json`
+4. Environment variable overrides
+
+Current supported environment overrides:
+
 - `MYTHIC_EXCERPT_LIMIT`
 - `MYTHIC_PACKET_CHAR_BUDGET`
 - `MYTHIC_AUTO_COMPACT`
 
-Inspect the effective config:
+Inspect effective configuration:
 
 ```bash
 mythic-vibe config --path .
 ```
 
-Example config file:
+Example config:
 
 ```json
 {
@@ -95,106 +177,95 @@ Example config file:
 }
 ```
 
-## ChatGPT Plus / Codex bridge flow
+---
 
-1) Generate a packet:
+## Command overview
 
-```bash
-mythic-vibe codex-pack \
-  --phase plan \
-  --task "Implement the CLI command parser and file templates" \
-  --audience beginner
-```
+Primary command families include:
 
-2) Open `mythic/codex_prompt.md` and paste the `Prompt To Paste` section into ChatGPT/Codex.
+- `init` / `imbue`
+- `codex-pack` / `evoke`
+- `doctor` / `scry`
+- `checkin`
+- `status`
+- `sync`
+- `method`
+- `weave`
+- `prune`
+- `heal`
+- `oath`
+- `grimoire add|list`
+- `config set`
+- `db migrate`
 
-3) Log the response summary:
-
-```bash
-mythic-vibe codex-log --phase build --response "Implemented parser with subcommands and docs updates"
-```
-
-4) Check current status:
-
-```bash
-mythic-vibe status
-```
-
-## Manual check-ins (without codex-log)
-
-```bash
-mythic-vibe checkin --phase intent --update "Defined user outcome and anti-goals"
-```
-
-## Project health diagnostics
-
-Run a quick structural + status validation:
-
-```bash
-mythic-vibe doctor
-```
-
-This checks required Mythic files, validates `mythic/status.json`, and reports any missing/invalid state.
-
-## Method sync commands
-
-Sync latest method notes from GitHub:
-
-```bash
-mythic-vibe sync
-```
-
-Print currently loaded method notes:
-
-```bash
-mythic-vibe method
-```
-
-## Ritual command aliases from the Mythic design doc
-
-The CLI now supports the design-doc style ritual commands in addition to existing commands:
-
-- `mythic imbue` (alias of `init`)
-- `mythic evoke` (alias of `codex-pack`)
-- `mythic scry` (alias of `doctor`)
-- `mythic weave`
-- `mythic prune`
-- `mythic heal`
-- `mythic oath`
-- `mythic grimoire add|list`
-- `mythic config set`
-- `mythic db migrate`
+For full command behavior and contracts, see `docs/api.md`.
 
 ---
 
-![https://raw.githubusercontent.com/hrabanazviking/Viking-Code-Mythic-Engineering-CLI-Vibe-Coding/refs/heads/main/Viking_Apache_V2_1.jpg](https://raw.githubusercontent.com/hrabanazviking/Viking-Code-Mythic-Engineering-CLI-Vibe-Coding/refs/heads/main/Viking_Apache_V2_1.jpg)
+## Repository posture (important)
+
+This repository contains multiple historical, research, and vendor islands. The active product path is:
+
+- **`mythic_vibe_cli/`**
+
+Supporting active paths include:
+
+- `tests/`
+- `docs/`
+- selected root governance records (`README`, `ARCHITECTURE`, `DATA_FLOW`, `DEVLOG`, `CHANGELOG`)
+
+Most other trees are not active CLI runtime dependencies and should be treated as reference or isolated experiments unless explicitly integrated by architecture decision.
+
+---
+
+## Documentation map
+
+Start here:
+
+1. `docs/INDEX.md` — canonical docs navigator
+2. `docs/quickstart.md` — setup + first loop
+3. `docs/ARCHITECTURE.md` — active runtime architecture
+4. `docs/DOMAIN_MAP.md` — ownership + boundaries
+5. `docs/api.md` — integration contracts
+6. `docs/SYSTEM_VISION.md` — product north star
+7. `DEVLOG.md` — chronological continuity record
+8. `CHANGELOG.md` — release-facing change history
+
+---
+
+## Development and quality checks
+
+Typical local checks:
+
+```bash
+pytest -q
+python -m mythic_vibe_cli.cli --help
+mythic-vibe doctor
+```
+
+(Availability depends on environment and install mode.)
+
+---
 
 ## License
 
 Copyright (c) 2026 Volmarr Wyrd
 
 Mythic Engineering is licensed under the Apache License, Version 2.0.
-See the [LICENSE](LICENSE) file for details.
+See `LICENSE` for details.
 
 Unless required by applicable law or agreed to in writing, this project is distributed on an "AS IS" BASIS, without warranties or conditions of any kind.
 
 ---
 
-## Distribution and Privacy Position
+## Distribution and privacy position
 
-Mythic-Engineering is published here as source code and project material.
+Mythic-Engineering is published as source code and project material.
 
-The author does not require users to provide age, identity, government ID, biometric data, or similar personal information in order to access or use the source code in this repository.
+The author does not require users to provide age, identity, government ID, biometric data, or similar personal information to access the source code in this repository.
 
-The author may decline to provide official binaries, installers, hosted services, app-store releases, or other official distribution channels where doing so would require age verification, identity verification, or similar personal-data collection.
+The author may decline official binaries/installers/hosted distribution channels where publication would require age or identity verification.
 
-Any third party who forks, packages, redistributes, deploys, hosts, or otherwise makes this software available does so independently and is solely responsible for compliance with applicable law, platform policy, and distribution requirements in their own jurisdiction and context.
+Any third party who forks, hosts, redistributes, or packages this software does so independently and is solely responsible for legal/platform compliance in their own context.
 
-See [LEGAL-NOTICE.md](LEGAL-NOTICE.md) for details.
-
----
-
-![https://raw.githubusercontent.com/hrabanazviking/Viking-Code-Mythic-Engineering-CLI-Vibe-Coding/refs/heads/main/IMG_0407.jpeg](https://raw.githubusercontent.com/hrabanazviking/Viking-Code-Mythic-Engineering-CLI-Vibe-Coding/refs/heads/main/IMG_0407.jpeg)
-
----
-
+See `LEGAL-NOTICE.md` for details.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,121 +2,182 @@
 
 **Status:** Active architecture record  
 **Last updated:** 2026-04-23  
-**Owner:** Architecture / Docs
+**Owner:** Architecture + Documentation maintainers  
+**Scope:** Active product runtime (`mythic_vibe_cli/`) and its governance boundaries in this monorepo.
 
-This document defines the active runtime architecture for this monorepo and the rules that prevent accidental coupling.
+This document is the architecture contract for contributors. It defines where runtime behavior lives, how dependencies may flow, and how to avoid accidental coupling to dormant islands.
 
 ---
 
 ## 1) Repository posture
 
-Treat this repository as a **multi-project monorepo** with one primary live product path:
+Treat this repository as a **multi-project monorepo**.
 
-1. **Mythic Vibe CLI** (`mythic_vibe_cli/`) — active runtime and operational entrypoint.
-2. **Legacy/runtime islands** (`ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`) — mostly dormant/fragmented.
-3. **Vendor/research islands** (`ollama/`, `whisper/`, `WYRD-.../`, specs/research corpora) — reference only unless explicitly integrated.
+### Active runtime product
 
-Default assumption: islands are independent unless a documented adapter contract exists.
+- `mythic_vibe_cli/`
+
+### Active support surfaces
+
+- `tests/`
+- `docs/`
+- root governance records (`README.md`, `ARCHITECTURE.md`, `DATA_FLOW.md`, `DEVLOG.md`, `CHANGELOG.md`)
+
+### Dormant/reference islands
+
+- runtime fragments (`ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`)
+- large protocol/research islands (`WYRD-...`, `mindspark_thoughtform/`)
+- vendor mirrors (`whisper/`, `chatterbox/`, `ollama/`)
+
+Default rule: islands are independent unless explicit adapter contracts are documented.
 
 ---
 
-## 2) Active system flow (Mythic Vibe CLI)
+## 2) Active system flow
 
 ```text
 User
   -> CLI Router (mythic_vibe_cli/cli.py)
     -> Workflow Orchestrator (workflow.py)
-    -> Prompt/Bridge Composer (codex_bridge.py)
-    -> Config Resolution (config.py)
-    -> Method Sync + Cache (mythic_data.py)
-      -> Project artifacts (docs/, tasks/, mythic/, DEVLOG.md, weave.db)
-      -> Optional external sync providers
+    -> Prompt Bridge (codex_bridge.py)
+    -> Config Resolver (config.py)
+    -> Method Data Sync/Cache (mythic_data.py)
+      -> Filesystem artifacts (docs/, tasks/, mythic/, DEVLOG.md)
+      -> Optional external method sync sources
 ```
-
-### Layer responsibilities
-
-- **`cli.py` (interface layer)**
-  - Defines commands/options and dispatches handlers.
-  - Keeps user-facing behavior coherent and predictable.
-
-- **`workflow.py` (orchestration layer)**
-  - Runs phase lifecycle and state transitions.
-  - Writes/updates durable artifacts.
-
-- **`codex_bridge.py` (prompt/packet layer)**
-  - Builds high-signal context packets.
-  - Applies compaction and budget constraints.
-
-- **`config.py` (configuration layer)**
-  - Resolves env/file/default precedence.
-  - Stays low-side-effect and stable.
-
-- **`mythic_data.py` (data/sync layer)**
-  - Handles method source sync/import/caching.
-  - Avoids owning orchestration logic.
 
 ---
 
-## 3) Dependency direction law
+## 3) Component responsibilities
 
-To keep architecture legible, dependency direction should remain one-way:
+### `mythic_vibe_cli/cli.py`
+
+- Defines command surface and argument contracts.
+- Dispatches behavior to orchestration layers.
+- Maintains user-facing ergonomics and stability.
+
+### `mythic_vibe_cli/workflow.py`
+
+- Owns phase transitions and lifecycle orchestration.
+- Creates/updates artifacts and state files.
+- Enforces sequence coherence for method execution.
+
+### `mythic_vibe_cli/codex_bridge.py`
+
+- Composes context packets for AI-assisted workflows.
+- Applies excerpting/compaction/budget policies.
+- Preserves explicit packet structure for reproducibility.
+
+### `mythic_vibe_cli/config.py`
+
+- Resolves layered configuration from defaults/files/environment.
+- Should remain deterministic and low side-effect.
+
+### `mythic_vibe_cli/mythic_data.py`
+
+- Handles sync/import/cache concerns for method data.
+- Encapsulates network/provider interactions.
+
+---
+
+## 4) Dependency direction law
+
+Allowed primary direction:
 
 1. `cli.py` -> `workflow`, `codex_bridge`, `config`, `mythic_data`
 2. `workflow.py` -> `config` + local artifact IO
-3. `codex_bridge.py` -> `config` + prepared workflow context
-4. `config.py` -> minimal dependencies
-5. `mythic_data.py` -> sync/cache concerns only
+3. `codex_bridge.py` -> `config` + prepared context
+4. `config.py` -> minimal dependencies only
+5. `mythic_data.py` -> provider/sync/cache concerns
 
-Any reversal requires an architecture decision record (ADR-style note in docs) before merge.
+Forbidden by default:
+
+- Reverse-layer imports that create cycles.
+- Imports from dormant runtime islands.
+- Imports from vendor mirrors directly into active CLI runtime.
+
+Any exception requires a documented architecture decision before merge.
 
 ---
 
-## 4) Boundary rules
+## 5) Filesystem interface contract
+
+Runtime behavior assumes stable interaction with:
+
+- `docs/` for governance/architecture records
+- `tasks/` for planning and execution tracking
+- `mythic/` for loop status/plan artifacts
+- root continuity records such as `DEVLOG.md` and `CHANGELOG.md`
+
+Renaming or relocating these without migration strategy is considered a breaking change.
+
+---
+
+## 6) Boundary rules
 
 ### Hard boundaries
 
-- `mythic_vibe_cli/` remains independently executable.
-- Dormant islands are not implicit runtime dependencies.
-- Vendor mirrors are not direct product import targets.
+- Active CLI remains independently executable.
+- Dormant islands are not implicit dependencies.
+- Vendor mirrors are not product runtime import targets.
 
 ### Soft boundaries
 
-- Cross-island reuse must enter via explicit adapters/interfaces.
-- Document contracts and data flow before adding wiring.
+- Cross-island reuse must be done through explicit adapters.
+- Adapter contracts must be documented before broad integration.
 
 ---
 
-## 5) Architecture risks
+## 7) Architecture risks
 
-- **Monorepo ambiguity:** contributors may edit the wrong island for active product behavior.
-- **Import drift:** accidental imports increase coupling and maintenance cost.
-- **Docs drift:** architecture/governance docs can diverge from runtime reality.
+1. **Monorepo ambiguity:** contributors may patch a look-alike module outside active path.
+2. **Import drift:** convenience imports can silently create coupling debt.
+3. **Contract drift:** docs may diverge from actual CLI behavior.
+4. **Overloaded bridge packets:** context packets can become noisy without budget discipline.
 
-Mitigation: require boundary verification commands in every meaningful PR.
+Mitigations:
+
+- explicit domain map checks,
+- required docs updates for behavior changes,
+- routine command-help and smoke tests,
+- changelog/devlog continuity discipline.
 
 ---
 
-## 6) Change protocol
+## 8) Change protocol
 
-When a change introduces any of the following, update this file in the same PR:
+Update this architecture record when introducing any of:
 
 - new runtime entrypoint,
-- new persistence/state contract,
-- new external dependency path,
-- new cross-island integration,
-- significant command lifecycle change.
+- changed phase lifecycle model,
+- new persisted state contract,
+- cross-island integration,
+- new external dependency route.
 
-Also update related records:
+Companion updates usually required:
 
 - `docs/DOMAIN_MAP.md`
-- root `ARCHITECTURE.md`
-- `DATA_FLOW.md` (if data movement changed)
+- `docs/api.md`
+- root `ARCHITECTURE.md` / `DATA_FLOW.md` (if repository-wide flow changed)
+- root `CHANGELOG.md` and `DEVLOG.md`
 
 ---
 
-## 7) Related records
+## 9) Review checklist for architecture-affecting PRs
 
-- Root deep-dive: `ARCHITECTURE.md`
-- Ownership boundaries: `docs/DOMAIN_MAP.md`
-- System direction: `docs/SYSTEM_VISION.md`
-- Operational flow details: `DATA_FLOW.md`
+- [ ] Active runtime paths are unchanged or intentionally migrated.
+- [ ] No forbidden cross-domain imports introduced.
+- [ ] Command/API docs updated.
+- [ ] Examples remain executable.
+- [ ] Changelog + devlog entries added for meaningful changes.
+
+---
+
+## 10) Related records
+
+- `docs/DOMAIN_MAP.md`
+- `docs/api.md`
+- `docs/SYSTEM_VISION.md`
+- `docs/INDEX.md`
+- root `ARCHITECTURE.md`
+- root `DATA_FLOW.md`

--- a/docs/DOMAIN_MAP.md
+++ b/docs/DOMAIN_MAP.md
@@ -1,16 +1,23 @@
 # Domain Map
 
 **Last updated:** 2026-04-23  
-**Owner:** Architecture / Docs  
+**Owner:** Architecture + Documentation maintainers  
 **Scope:** Entire repository
 
-This map is the routing law for where code and docs belong.
+This domain map defines ownership, routing, and boundary rules so contributors can place work correctly in a large monorepo.
 
 ---
 
 ## 1) Why this exists
 
-In a multi-project monorepo, contributors can unintentionally modify dormant or vendor areas while trying to ship active product behavior. This document prevents that drift by defining ownership and forbidden dependencies.
+Without explicit routing, large repositories accumulate accidental edits in dormant or vendor areas. The result is hidden coupling, fragile releases, and confusing ownership.
+
+This file prevents that by documenting:
+
+- where active product behavior belongs,
+- what each domain owns,
+- what each domain must not own,
+- which dependencies are disallowed.
 
 ---
 
@@ -18,13 +25,13 @@ In a multi-project monorepo, contributors can unintentionally modify dormant or 
 
 | Domain | Primary paths | Status | Owns | Must not own |
 |---|---|---|---|---|
-| Product CLI | `mythic_vibe_cli/`, `tests/`, packaging files | **Active** | Command contracts, workflow lifecycle, config, prompt packet generation, method sync | Vendor mirrors, research corpus, dormant runtime islands |
-| Governance Docs | `docs/`, root architecture/governance docs | **Active** | Architecture records, operating rules, contributor orientation | Runtime implementation logic |
-| Skills & Agent Modes | `skills/`, `.claude/`, `.roo/` | **Active** | Reusable workflows/personas and execution guidance | Product runtime code |
-| Legacy Runtime Cluster | `ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`, `imports/norsesaga/` | Dormant/fragmented | Historical experiments and partial runtime systems | New product-critical features without explicit architecture decision |
-| Thoughtform Island | `mindspark_thoughtform/` | Dormant/self-contained | Research implementation experiments | CLI production dependencies |
-| WYRD Protocol Island | `WYRD-Protocol-World-Yielding-Real-time-Data-AI-world-model/` | Dormant/self-contained | Protocol/world-model exploration | CLI production dependencies |
-| Vendor Mirrors | `ollama/`, `whisper/`, `chatterbox/` | Snapshot/reference | Upstream code mirrors | Direct import targets in active CLI |
+| Product CLI | `mythic_vibe_cli/`, `tests/`, packaging files | **Active** | Command contracts, workflow lifecycle, config, prompt packets, method sync | Vendor mirrors, dormant islands, unrelated research runtimes |
+| Governance Docs | `docs/`, root architecture/governance docs | **Active** | Architecture records, onboarding, standards, release notes | Runtime implementation logic |
+| Skills & Agent Modes | `skills/`, `.claude/`, `.roo/` | **Active** | Reusable execution/persona workflows | Product runtime behavior |
+| Legacy Runtime Cluster | `ai/`, `core/`, `systems/`, `sessions/`, `yggdrasil/`, `imports/norsesaga/` | Dormant/fragmented | Historical experiments and archived runtime ideas | New product-critical behavior without architecture decision |
+| Thoughtform Island | `mindspark_thoughtform/` | Dormant/self-contained | Experimental cognition systems | Direct CLI runtime dependencies |
+| WYRD Protocol Island | `WYRD-Protocol-.../` | Dormant/self-contained | World-model/protocol experiments | Direct CLI runtime dependencies |
+| Vendor Mirrors | `ollama/`, `whisper/`, `chatterbox/` | Snapshot/reference | Upstream source mirrors | Direct active CLI imports |
 | Research Corpus | `research_data/`, `docs/research/`, `docs/specs/` | Informational | Theory/spec references | Authoritative runtime behavior |
 
 ---
@@ -34,47 +41,52 @@ In a multi-project monorepo, contributors can unintentionally modify dormant or 
 ### Product CLI (`mythic_vibe_cli/*`)
 
 Allowed:
-- Python stdlib and declared package dependencies.
+
+- Python stdlib + declared package dependencies.
 - Internal imports within `mythic_vibe_cli/`.
-- File IO for project scaffolds and operational artifacts.
-- Explicit network access in sync/import paths.
+- Artifact IO for project scaffolding/state.
+- Explicit network calls only in sync/import paths.
 
 Forbidden:
+
 - Imports from dormant runtime clusters.
 - Imports from Thoughtform/WYRD islands.
-- Imports from vendor mirrors.
+- Imports from vendor mirrors (`ollama`, `whisper`, `chatterbox`).
 
-### Docs and skills domains
+### Documentation and skills domains
 
 Allowed:
-- References to stable repository-relative paths.
+
+- Stable repository-relative references.
 
 Forbidden:
-- Secrets, machine-specific absolute paths, undocumented production assumptions.
+
+- Secrets or machine-specific absolute paths.
+- Operational instructions that contradict active architecture.
 
 ---
 
-## 4) Ownership map for active CLI
+## 4) Active CLI ownership map
 
 | Subdomain | Canonical owner |
 |---|---|
-| Command surface and args | `mythic_vibe_cli/cli.py` |
+| Command surface and aliases | `mythic_vibe_cli/cli.py` |
 | Workflow lifecycle and phase transitions | `mythic_vibe_cli/workflow.py` |
-| Config precedence and coercion | `mythic_vibe_cli/config.py` |
-| Prompt packet synthesis and compaction | `mythic_vibe_cli/codex_bridge.py` |
-| Method sync/import/caching | `mythic_vibe_cli/mythic_data.py` |
+| Configuration precedence and coercion | `mythic_vibe_cli/config.py` |
+| Prompt packet synthesis and budget logic | `mythic_vibe_cli/codex_bridge.py` |
+| Method sync/import/cache | `mythic_vibe_cli/mythic_data.py` |
 
 ---
 
 ## 5) Routing rules for new work
 
-- New command or alias -> `mythic_vibe_cli/cli.py`
-- New workflow phase/state behavior -> `mythic_vibe_cli/workflow.py`
-- New configuration setting -> `mythic_vibe_cli/config.py`
-- New packet section/formatting -> `mythic_vibe_cli/codex_bridge.py`
-- New sync provider/parser -> `mythic_vibe_cli/mythic_data.py`
-- New governance documentation -> `docs/` + corresponding root records
-- New agent workflow/skill -> `skills/<skill-name>/`
+- New CLI command/alias -> `mythic_vibe_cli/cli.py`
+- New phase/state logic -> `mythic_vibe_cli/workflow.py`
+- New config option or precedence behavior -> `mythic_vibe_cli/config.py`
+- New prompt packet section/format -> `mythic_vibe_cli/codex_bridge.py`
+- New sync provider/parser/cache path -> `mythic_vibe_cli/mythic_data.py`
+- New governance document -> `docs/` + linked root records
+- New repeatable agent workflow -> `skills/<skill-name>/`
 
 ---
 
@@ -82,9 +94,42 @@ Forbidden:
 
 A change is compliant only if all are true:
 
-1. It stays inside the proper owning domain.
-2. It introduces no forbidden cross-domain import.
-3. It updates governance docs when ownership/boundaries shift.
-4. It includes verification commands relevant to changed domains.
+1. It remains in the proper owning domain.
+2. It introduces no forbidden imports.
+3. Governance docs are updated when behavior/ownership changes.
+4. Tests/checks relevant to affected domains were executed.
+5. Release/session continuity records were updated for meaningful deltas.
 
-If any check fails, treat the change as architectural drift and fix before merge.
+---
+
+## 7) Escalation path for boundary exceptions
+
+If a change truly needs cross-domain wiring:
+
+1. Document intent and reason in architecture docs.
+2. Define explicit adapter boundaries.
+3. Add tests proving boundary contract behavior.
+4. Record rationale in `DEVLOG.md` and summarize in `CHANGELOG.md`.
+
+No silent exceptions.
+
+---
+
+## 8) Drift indicators
+
+Investigate immediately if you see:
+
+- Active CLI imports from dormant islands.
+- New docs describing behavior not present in runtime.
+- Contributors editing vendor mirrors for product fixes.
+- Duplicate logic appearing in both active and dormant paths.
+
+---
+
+## 9) Related docs
+
+- `docs/ARCHITECTURE.md`
+- `docs/api.md`
+- `docs/INDEX.md`
+- root `ARCHITECTURE.md`
+- root `DEVLOG.md`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,108 @@
+# Mythic Vibe CLI Documentation Index
+
+**Status:** Canonical documentation navigation map  
+**Last updated:** 2026-04-23  
+**Audience:** Users, contributors, maintainers, and future selves returning after context loss.
+
+This index is the front door to the active documentation suite.
+
+---
+
+## 1) Start paths by role
+
+### New user path (10–20 minutes)
+
+1. `quickstart.md`
+2. `SYSTEM_VISION.md`
+3. `api.md` (CLI entrypoints section)
+
+### Contributor path (20–40 minutes)
+
+1. `ARCHITECTURE.md`
+2. `DOMAIN_MAP.md`
+3. `api.md`
+4. Root `DEVLOG.md` and `CHANGELOG.md`
+
+### Maintainer / release path
+
+1. Root `CHANGELOG.md`
+2. Root `DEVLOG.md`
+3. `ARCHITECTURE.md`
+4. `DOMAIN_MAP.md`
+
+---
+
+## 2) Core active docs
+
+- `quickstart.md` — setup, first execution loop, troubleshooting.
+- `SYSTEM_VISION.md` — product purpose, promises, anti-goals.
+- `ARCHITECTURE.md` — active runtime architecture and dependency law.
+- `DOMAIN_MAP.md` — ownership boundaries and routing rules.
+- `api.md` — CLI/module contracts and filesystem interface.
+- Root `README.md` — project-level overview and command orientation.
+- Root `DEVLOG.md` — continuity record of major sessions.
+- Root `CHANGELOG.md` — user-facing change history.
+
+---
+
+## 3) Source-of-truth boundaries
+
+In case of disagreement between records:
+
+1. Runtime behavior in `mythic_vibe_cli/` is ground truth for executable behavior.
+2. `docs/ARCHITECTURE.md` defines active architecture intent.
+3. `docs/DOMAIN_MAP.md` defines ownership and allowed boundaries.
+4. `docs/api.md` defines user/integration-facing contracts.
+5. Root `DEVLOG.md` preserves chronology and rationale.
+6. Root `CHANGELOG.md` summarizes release-facing deltas.
+
+If this order causes confusion, treat that as a docs bug and repair it in the same PR.
+
+---
+
+## 4) Documentation upkeep protocol
+
+When you change behavior, update documentation in the same pull request:
+
+- Command or output change -> `api.md` + `quickstart.md`
+- Workflow/lifecycle change -> `ARCHITECTURE.md` + `api.md`
+- Boundary ownership change -> `DOMAIN_MAP.md` + `ARCHITECTURE.md`
+- Product positioning change -> `SYSTEM_VISION.md` + `README.md`
+- Meaningful user-facing change -> `CHANGELOG.md`
+- Session-level rationale/decision history -> `DEVLOG.md`
+
+---
+
+## 5) Drift signals (act immediately)
+
+Treat these as warnings that documentation drift is occurring:
+
+- CLI help text differs from examples in docs.
+- New files/commands exist without any mention in docs.
+- Runtime imports cross forbidden domain boundaries.
+- `README.md` promises behavior that tests or command help do not show.
+- `DEVLOG.md` lacks entries for significant architecture decisions.
+
+---
+
+## 6) Naming and style rules
+
+- Prefer explicit, searchable headings over poetic ambiguity.
+- Use absolute dates (`YYYY-MM-DD`) for durable chronology.
+- Prefer stable paths in examples and avoid machine-specific absolute paths.
+- Keep each doc answerable to a clear owner/scope.
+- Avoid duplicating long content across multiple docs; link to source-of-truth files.
+
+---
+
+## 7) Companion hubs
+
+- `docs/index.md` — reader-friendly documentation hub for quick orientation.
+- Root `ARCHITECTURE.md` and `DATA_FLOW.md` — deeper repository-level records.
+- `docs/research/` and `docs/specs/` — reference material, not active CLI runtime contracts.
+
+---
+
+## 8) Archival note
+
+Documentation is treated as part of the product surface. If code changes are merged without matching documentation updates, continuity debt accumulates and should be corrected with priority.

--- a/docs/SYSTEM_VISION.md
+++ b/docs/SYSTEM_VISION.md
@@ -2,38 +2,45 @@
 
 ## Purpose
 
-Mythic Vibe CLI exists to make disciplined software creation accessible to ordinary builders by turning intent into repeatable execution loops.
+Mythic Vibe CLI exists to help people build software with **intentional structure and durable continuity**. It is designed as an engineering companion that turns ambition into tractable loops, and loops into preserved progress.
 
-The system should feel like a dependable co-navigator: structured enough to prevent drift, flexible enough to preserve creativity, and explicit enough to maintain team alignment over time.
+The system should feel like a calm, reliable co-navigator:
+
+- structured enough to prevent drift,
+- flexible enough to keep creative momentum,
+- explicit enough to support handoffs and long-lived maintenance.
 
 ---
 
 ## North Star
 
-Enable individuals and small teams to move from idea to resilient implementation through a transparent phase method:
+Enable individuals and small teams to move from idea to resilient implementation through a transparent method loop:
 
 `intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
 
-Success means users can repeatedly ship coherent outcomes with fewer rewrites, clearer decisions, and better continuity across sessions.
+Success means users can repeatedly deliver coherent outcomes with fewer rewrites, clearer decisions, and stronger session-to-session continuity.
 
 ---
 
 ## Product promises
 
-1. **Architecture-first by default**
-   Encourage goal/constraint/design clarity before implementation.
+1. **Architecture-first by default**  
+   Encourage builders to model goals, constraints, and system boundaries before coding.
 
-2. **Beginner-friendly, expert-capable**
-   Keep the default loop understandable while supporting advanced depth.
+2. **Beginner-friendly, expert-capable**  
+   Keep baseline workflows understandable while preserving depth for advanced operators.
 
-3. **Traceable progress**
-   Each meaningful action leaves durable artifacts for future recovery.
+3. **Traceable progress**  
+   Each meaningful action should produce artifacts that can be reviewed later.
 
-4. **Practical human + AI collaboration**
-   Structured prompt packets should improve quality without obscuring method.
+4. **Practical human + AI collaboration**  
+   Prompt packets should improve signal quality, not obscure responsibility.
 
-5. **Method fidelity without rigidity**
-   Enforce healthy defaults while permitting intentional adaptation.
+5. **Method fidelity without rigidity**  
+   Strong defaults should guide, not imprison, healthy adaptation.
+
+6. **Recoverability over heroic memory**  
+   Work should survive interruptions, context loss, and contributor turnover.
 
 ---
 
@@ -41,50 +48,60 @@ Success means users can repeatedly ship coherent outcomes with fewer rewrites, c
 
 ### In scope
 
-- Project initialization and method-aligned scaffolding.
+- Project initialization + method-aligned scaffolding.
 - Workflow commands for planning, check-ins, diagnostics, and status.
-- Documentation scaffolding and process reinforcement.
-- Prompt packet generation and response logging for AI collaboration.
+- Structured prompt packet generation and response logging.
+- Documentation/process reinforcement for continuity.
 
 ### Out of scope
 
 - Replacing engineering judgment.
-- Fully autonomous implementation without review.
-- Vendor lock-in to a single model/service/provider.
+- Fully autonomous implementation without human review.
+- Provider lock-in to a single model/service.
+- Implicit hidden state that cannot be inspected or repaired.
 
 ---
 
 ## Design principles
 
-- **Clarity over cleverness:** command behavior should be legible.
-- **Artifacts over memory:** key decisions belong in files.
-- **Small loops, fast feedback:** favor incremental progress + verification.
-- **Stable defaults, configurable edges:** safe defaults with power-user control.
-- **Transparency over magic:** explain why the tool guides/enforces steps.
+- **Clarity over cleverness** — behavior should be legible.
+- **Artifacts over memory** — key decisions belong in files.
+- **Small loops, fast feedback** — incremental progress beats fragile leaps.
+- **Stable defaults, configurable edges** — protect beginners while enabling experts.
+- **Transparency over magic** — explain why the system asks for each step.
+- **Continuity over novelty** — prefer workflows that remain useful over time.
 
 ---
 
-## UX expectations
+## User experience expectations
 
 A user should be able to:
 
 1. Initialize or adopt a project quickly.
-2. See current phase and phase-completion criteria.
-3. Generate high-signal AI context without losing method structure.
-4. Resume work days later using durable artifacts.
-5. Diagnose project health rapidly when momentum stalls.
+2. Understand current phase and completion criteria.
+3. Generate high-signal AI context without abandoning method structure.
+4. Resume work after delay with minimal reconstruction.
+5. Diagnose and repair stalled momentum with clear guidance.
+
+A maintainer should be able to:
+
+1. Trace rationale behind significant decisions.
+2. Review release-facing changes clearly.
+3. Validate boundary compliance in a large monorepo.
+4. Onboard a new contributor through docs alone.
 
 ---
 
 ## Quality bar
 
-A high-quality Mythic Vibe CLI interaction is:
+High-quality Mythic Vibe CLI behavior is:
 
-- **Coherent:** behavior reinforces one mental model.
-- **Recoverable:** state can be inspected and repaired.
-- **Documented:** rationale and outcomes are captured.
-- **Composable:** workflows chain cleanly across phases.
-- **Trustworthy:** diagnostics reflect actual project state.
+- **Coherent** — interactions reinforce one mental model.
+- **Recoverable** — state can be inspected and corrected.
+- **Documented** — rationale and outcomes are preserved.
+- **Composable** — workflow steps chain cleanly.
+- **Trustworthy** — diagnostics reflect actual system state.
+- **Durable** — artifacts remain useful beyond a single session.
 
 ---
 
@@ -92,16 +109,23 @@ A high-quality Mythic Vibe CLI interaction is:
 
 ### Near-term priorities
 
-1. Clearer phase guidance and error messaging.
-2. Better diagnostics with concrete remediation.
-3. Higher-signal prompt packet composition.
-4. Stronger governance templates and contributor onboarding.
+1. Sharper phase guidance and error remediation messaging.
+2. Better diagnostics with concrete fix recommendations.
+3. Higher-signal context packet composition controls.
+4. Stronger contributor onboarding and governance records.
+5. Consistent release history discipline via changelog practices.
+
+### Mid-term opportunities
+
+- richer state introspection tooling,
+- stronger template systems for planning docs,
+- improved integration surfaces for external tooling.
 
 ### Long-term opportunities
 
-- Multi-agent orchestration patterns.
-- Richer memory/retrieval integrations.
-- Expanded ritual command ecosystem with explicit guardrails.
+- multi-agent coordination patterns,
+- memory/retrieval extensions with explicit guardrails,
+- broader ritual command ecosystem with maintainable contracts.
 
 ---
 
@@ -109,13 +133,13 @@ A high-quality Mythic Vibe CLI interaction is:
 
 The system should not become:
 
-- A black-box agent that hides decisions,
-- A process bureaucracy that blocks delivery,
-- A style-policing layer detached from outcomes,
-- A workflow hard-locked to one external vendor.
+- a black-box agent that hides decisions,
+- a process bureaucracy detached from delivery,
+- a style-policing layer that ignores outcomes,
+- an opaque wrapper around external vendors.
 
 ---
 
 ## Final vision statement
 
-Mythic Vibe CLI is an engineering compass: a toolchain that helps humans and AI build software with stronger intent, clearer structure, and durable continuity from first idea to maintained system.
+Mythic Vibe CLI is an engineering compass: a toolchain that helps humans and AI create software with stronger intent, clearer structure, and preserved continuity from first concept through long-term maintenance.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,109 +1,196 @@
 # API Reference
 
-This document describes the primary integration surfaces for the active **Mythic Vibe CLI** product path.
+This document defines the primary integration surfaces for the active **Mythic Vibe CLI** product path.
 
-> Note: This repository contains historical and research artifacts. Treat this file as authoritative only for active CLI-facing APIs/workflows.
+> Scope note: this repository contains historical and research artifacts. This API record is authoritative only for active CLI-facing behavior.
 
 ---
 
-## 1) CLI entrypoint
+## 1) Entrypoints
 
-### Module execution
+### Installed CLI (preferred for day-to-day use)
+
+```bash
+mythic --help
+# or
+mythic-vibe --help
+```
+
+### Module execution (useful for debugging/install edge cases)
 
 ```bash
 python -m mythic_vibe_cli.cli --help
 ```
 
-### Installed command (environment-dependent)
+---
 
-```bash
-mythic --help
-```
+## 2) Command contracts (high-level)
 
-If both are available, prefer the installed command for daily use and module execution for debugging.
+### Initialization and setup
+
+- `init` (alias: `imbue`)
+  - Initializes a project scaffold aligned to method phases.
+
+### Prompt bridge and AI collaboration
+
+- `codex-pack` (alias: `evoke`)
+  - Produces structured context packet artifacts for ChatGPT/Codex.
+- `codex-log`
+  - Records response summaries for continuity.
+
+### Workflow continuity
+
+- `checkin`
+  - Persists structured phase updates.
+- `status`
+  - Reports current progress and phase state.
+
+### Health and method state
+
+- `doctor` (alias: `scry`)
+  - Checks structural and state validity.
+- `sync`
+  - Pulls method content from configured source.
+- `method`
+  - Displays loaded method notes.
+
+### Extended ritual surfaces
+
+Depending on implementation state, additional commands may be exposed:
+
+- `weave`
+- `prune`
+- `heal`
+- `oath`
+- `grimoire add|list`
+- `config set`
+- `db migrate`
+
+Use `--help` for current option details and defaults.
 
 ---
 
-## 2) Core modules and contracts
+## 3) Core module contracts
 
 ### `mythic_vibe_cli.cli`
 
 Responsibility:
-- command surface,
-- argument parsing,
-- dispatch to workflow/config/data subsystems.
 
-Contract guidance:
-- Keep command names and flags stable once published.
-- Add aliases only when they do not create ambiguity.
+- command definitions,
+- argument parsing,
+- dispatch boundaries.
+
+Contract expectations:
+
+- published flags remain stable where practical,
+- aliases avoid ambiguity,
+- error output is actionable.
 
 ### `mythic_vibe_cli.workflow`
 
 Responsibility:
-- orchestrates phase loop,
-- manages artifact creation/updates,
-- supports status/check-in behavior.
 
-Contract guidance:
-- Preserve deterministic phase ordering unless explicitly versioned.
-- Emit actionable errors with remediation hints.
+- phase sequencing,
+- artifact updates,
+- continuity state changes.
+
+Contract expectations:
+
+- deterministic phase transitions,
+- explicit remediation hints on failure,
+- no hidden global side effects.
 
 ### `mythic_vibe_cli.config`
 
 Responsibility:
-- resolve layered configuration from defaults + files + env.
 
-Contract guidance:
-- Document precedence in code comments and user docs.
-- Avoid side effects during parse/load.
+- layered config resolution and coercion.
+
+Contract expectations:
+
+- documented precedence,
+- deterministic parsing,
+- low side-effect initialization.
 
 ### `mythic_vibe_cli.codex_bridge`
 
 Responsibility:
-- compose prompt/context packets,
-- apply compaction and budget logic.
 
-Contract guidance:
-- Prefer explicit section boundaries.
-- Keep packet outputs inspectable and reproducible.
+- context packet assembly,
+- budget-aware compaction,
+- stable packet sectioning.
+
+Contract expectations:
+
+- reproducible output from same input/config,
+- explicit section boundaries,
+- transparent truncation/compaction behavior.
 
 ### `mythic_vibe_cli.mythic_data`
 
 Responsibility:
-- sync/import/cache method data from supported providers.
 
-Contract guidance:
-- Isolate network concerns here.
-- Avoid absorbing orchestration responsibilities.
+- method sync/import/cache logic.
 
----
+Contract expectations:
 
-## 3) Artifact interface (filesystem contract)
-
-CLI workflows interact with project artifacts such as:
-
-- `docs/` (governance and architecture notes)
-- `tasks/` (execution plans/checklists)
-- `mythic/` (method/runtime state)
-- `DEVLOG.md` and related operational logs
-- local cache/state files (for example `weave.db` where applicable)
-
-These are part of the product contract: if you rename or relocate them, update docs and migration behavior together.
+- provider/network logic isolated here,
+- graceful degradation on network faults,
+- no orchestration leakage into data layer.
 
 ---
 
-## 4) Backward compatibility guidance
+## 4) Filesystem interface contract
 
-When changing CLI/API behavior:
+The CLI operates on durable artifacts, including:
 
-1. Prefer additive changes over breaking renames.
-2. If breaking, provide migration notes in the same PR.
-3. Update `docs/quickstart.md` and architecture docs concurrently.
-4. Include verification commands proving new behavior.
+- `docs/` — architecture and governance records,
+- `tasks/` — plans/checklists,
+- `mythic/` — method/runtime state files,
+- root records such as `DEVLOG.md` and `CHANGELOG.md`,
+- local state files (e.g., `weave.db`, when enabled).
+
+Any relocation/rename should be handled as a breaking change with migration notes.
 
 ---
 
-## 5) Example integration pattern (subprocess)
+## 5) Configuration interface summary
+
+Precedence order (low -> high):
+
+1. `~/.mythic-vibe.json`
+2. `$XDG_CONFIG_HOME/mythic-vibe/config.json`
+3. `<project>/.mythic-vibe.json`
+4. environment variables
+
+Known env overrides include:
+
+- `MYTHIC_EXCERPT_LIMIT`
+- `MYTHIC_PACKET_CHAR_BUDGET`
+- `MYTHIC_AUTO_COMPACT`
+
+Inspect current resolved config with:
+
+```bash
+mythic-vibe config --path .
+```
+
+---
+
+## 6) Compatibility policy
+
+When behavior changes:
+
+1. Prefer additive changes over breaking ones.
+2. If breaking, include migration notes in the same PR.
+3. Update `docs/quickstart.md`, `docs/api.md`, and architecture docs together.
+4. Include verification commands that prove new behavior.
+
+---
+
+## 7) Integration examples
+
+### Subprocess integration
 
 ```python
 import subprocess
@@ -117,27 +204,21 @@ result = subprocess.run(
 print(result.stdout)
 ```
 
-Use subprocess execution when integrating from external tooling to keep process boundaries explicit.
-
----
-
-## 6) Example integration pattern (in-repo module import)
+### In-repo module usage (pattern)
 
 ```python
-# Pseudocode pattern: import only stable module surfaces.
 from mythic_vibe_cli import cli, workflow, config
 
-# Build your wrapper around documented commands/workflows
-# rather than reaching into private helper internals.
+# Build wrappers around documented surfaces
+# rather than private helpers.
 ```
-
-Prefer public, stable functions and avoid coupling to private helpers.
 
 ---
 
-## 7) Change checklist for API-affecting PRs
+## 8) API-change PR checklist
 
-- [ ] CLI help/output updated where relevant
-- [ ] Docs updated (`quickstart`, `api`, and architecture/domain docs as needed)
-- [ ] Tests/checks run and recorded
-- [ ] Boundary rules validated (no forbidden cross-island imports)
+- [ ] Help output/examples updated where relevant
+- [ ] Docs updated (`quickstart`, `api`, architecture/domain docs)
+- [ ] Tests/checks executed and recorded
+- [ ] Boundary rules validated
+- [ ] Continuity records updated (`DEVLOG`, `CHANGELOG`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,20 @@
 # Mythic Vibe CLI Documentation Hub
 
-Welcome to the canonical documentation hub for **Mythic Vibe CLI**, a method-driven command-line tool for building software through explicit engineering phases.
+Welcome to the active documentation hub for **Mythic Vibe CLI**, a method-driven command-line system for building software with explicit phases, durable artifacts, and cleaner collaboration handoffs.
 
-> If you are new, start with **Quickstart**. If you are contributing, read **Architecture** and **Domain Map** next.
+If you are new, begin with `quickstart.md`. If you are contributing, begin with `ARCHITECTURE.md` and `DOMAIN_MAP.md`.
+
+> Canonical navigation map: `docs/INDEX.md`.
 
 ---
 
-## What this project is
+## What this project does
 
-Mythic Vibe CLI helps you move from idea to implementation with a repeatable workflow:
+Mythic Vibe CLI helps builders move from idea to implementation via a repeatable engineering loop:
 
 `intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
 
-Instead of relying on implicit memory, the CLI writes decisions into durable artifacts so you can pause, resume, and collaborate with less confusion.
+Rather than relying on memory alone, the CLI writes structured artifacts so sessions can pause and resume without losing rationale.
 
 ---
 
@@ -20,58 +22,65 @@ Instead of relying on implicit memory, the CLI writes decisions into durable art
 
 ### Start here
 
-1. **[Quickstart](quickstart.md)**
-   Install, initialize, and run your first project loop.
-2. **[System Vision](SYSTEM_VISION.md)**
-   Product intent, quality bar, and long-term direction.
-3. **[Architecture](ARCHITECTURE.md)**
-   Active runtime boundaries and dependency direction.
+1. **[Quickstart](quickstart.md)**  
+   Installation, setup, first operational loop, and troubleshooting.
+2. **[System Vision](SYSTEM_VISION.md)**  
+   Product goals, promises, anti-goals, and evolution strategy.
+3. **[Architecture](ARCHITECTURE.md)**  
+   Active runtime boundaries, component responsibilities, and dependency direction.
 
 ### Governance and boundaries
 
-- **[Domain Map](DOMAIN_MAP.md)** — source-of-truth ownership map for active vs dormant domains.
-- **[API Reference](api.md)** — public Python and CLI integration surfaces.
-- **[Hardware Profiles](hardware_profiles.md)** — deployment guidance for constrained and high-end machines.
+- **[Domain Map](DOMAIN_MAP.md)** — authoritative ownership map for active vs dormant domains.
+- **[API Reference](api.md)** — CLI/module interfaces and filesystem contracts.
+- **[Hardware Profiles](hardware_profiles.md)** — execution guidance for constrained and high-end environments.
 
----
+### Continuity and release history
 
-## Who this is for
-
-- **Solo builders** who need a reliable workflow, not just command sprawl.
-- **Small teams** who want traceable decisions and better handoffs.
-- **AI-assisted developers** who need structured context packets and method continuity.
+- **[Root DEVLOG](../DEVLOG.md)** — chronological record of meaningful decisions and sessions.
+- **[Root CHANGELOG](../CHANGELOG.md)** — release-facing summary of what changed and why it matters.
 
 ---
 
 ## Recommended reading paths
 
-### Path A: New user (10–15 minutes)
+### Path A — First-time user (10–15 minutes)
 
-1. Read [Quickstart](quickstart.md)
-2. Run one full CLI loop
-3. Scan [System Vision](SYSTEM_VISION.md)
+1. Read [Quickstart](quickstart.md).
+2. Run one complete phase loop.
+3. Skim [System Vision](SYSTEM_VISION.md).
+4. Bookmark [API Reference](api.md) for commands and contracts.
 
-### Path B: Contributor / maintainer (20–30 minutes)
+### Path B — Contributor (20–30 minutes)
 
-1. Read [Architecture](ARCHITECTURE.md)
-2. Read [Domain Map](DOMAIN_MAP.md)
-3. Review [API Reference](api.md)
-4. Verify boundaries before opening a PR
+1. Read [Architecture](ARCHITECTURE.md).
+2. Read [Domain Map](DOMAIN_MAP.md).
+3. Read [API Reference](api.md).
+4. Review [Root DEVLOG](../DEVLOG.md) for recent decisions.
+
+### Path C — Maintainer / release owner
+
+1. Review [Root CHANGELOG](../CHANGELOG.md).
+2. Validate docs remain synchronized with behavior.
+3. Verify boundary and dependency rules before merge.
 
 ---
 
-## Documentation standards
+## Documentation discipline
 
-When you update runtime behavior, update docs in the same PR:
+When behavior changes, update documentation in the same PR:
 
-- **Behavior change** -> `api.md` and/or `quickstart.md`
-- **Boundary/ownership change** -> `ARCHITECTURE.md` and `DOMAIN_MAP.md`
-- **Product direction change** -> `SYSTEM_VISION.md`
+- Behavior or command contract changes -> `api.md` and/or `quickstart.md`
+- Architecture or flow changes -> `ARCHITECTURE.md`
+- Ownership/boundary changes -> `DOMAIN_MAP.md`
+- Product intent changes -> `SYSTEM_VISION.md` and `README.md`
+- Session continuity context -> `DEVLOG.md`
+- User-facing release summary -> `CHANGELOG.md`
 
 If docs and behavior diverge, treat it as a bug.
 
 ---
 
-## Project status note
+## Active product status note
 
-This repository is a multi-project monorepo. The active product path is **`mythic_vibe_cli/`**. Other trees include research, vendor mirrors, and historical/runtime experiments that are not primary CLI execution paths.
+This repository is a multi-project monorepo. The active product runtime path is **`mythic_vibe_cli/`**. Other trees include research material, vendor mirrors, and isolated historical/runtime experiments.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,18 +1,22 @@
 # Quickstart
 
-Get Mythic Vibe CLI running quickly and complete your first structured workflow loop.
+This guide gets Mythic Vibe CLI running and walks you through one clean, end-to-end workflow cycle with artifact continuity.
 
 ---
 
 ## 1) Prerequisites
 
+### Required
+
 - Python 3.10+
 - Git
-- A shell environment (bash, zsh, PowerShell, or equivalent)
+- A shell (`bash`, `zsh`, `fish`, PowerShell, etc.)
 
-Optional but useful:
-- A virtual environment tool (`venv`, `uv`, or `conda`)
-- An editor with Python linting and formatting support
+### Recommended
+
+- A virtual environment (`venv`, `uv`, or `conda`)
+- An editor with Python linting/formatting
+- `pytest` for local verification loops
 
 ---
 
@@ -26,69 +30,143 @@ source .venv/bin/activate  # Windows PowerShell: .\.venv\Scripts\Activate.ps1
 pip install -e .
 ```
 
-If editable install is not configured in your environment, install dependencies from the project’s packaging files and run the module directly.
+If editable install is unavailable in your environment, run the CLI via module mode:
+
+```bash
+python -m mythic_vibe_cli.cli --help
+```
 
 ---
 
-## 3) Verify the CLI is available
+## 3) Verify installation
 
-Run one of the following (depending on your setup):
+Run one of:
 
 ```bash
 mythic --help
 # or
+mythic-vibe --help
+# or
 python -m mythic_vibe_cli.cli --help
 ```
 
-You should see command help text and available workflow operations.
+Expected result: command list and option help text.
 
 ---
 
-## 4) Initialize a working loop
+## 4) Initialize a project scaffold
 
-Use the CLI to initialize/adopt a project and enter the method loop:
+Example:
+
+```bash
+mythic-vibe init --goal "Build a beginner-friendly TODO app" --noob
+```
+
+This initializes a method-aligned project skeleton with core artifacts in `docs/`, `tasks/`, and `mythic/`.
+
+---
+
+## 5) Run your first loop
+
+The canonical sequence is:
 
 `intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
 
-At each phase, capture outputs in project artifacts (for example, docs and task notes) so the next session starts with context.
+At each step:
+
+1. Decide and document.
+2. Execute a narrow action.
+3. Verify before moving forward.
+4. Preserve rationale in artifacts.
+
+This keeps AI interactions useful without losing your own design intent.
 
 ---
 
-## 5) Daily operating pattern (recommended)
+## 6) Bridge workflow for ChatGPT/Codex
 
-1. **Check current status** (what phase, what’s blocked, what’s next).
-2. **Run the next phase command**.
-3. **Record decisions and rationale** in artifacts.
-4. **Verify outcomes** with tests/checks.
-5. **Log reflection** so future sessions resume cleanly.
+Generate a prompt packet:
 
-This operating pattern is the fastest way to avoid drift and repeated rework.
+```bash
+mythic-vibe codex-pack \
+  --phase plan \
+  --task "Implement parser and template generation" \
+  --audience beginner
+```
+
+Then:
+
+1. Open `mythic/codex_prompt.md`.
+2. Paste the packet into ChatGPT/Codex.
+3. Execute/curate resulting changes.
+4. Log outcomes:
+
+```bash
+mythic-vibe codex-log --phase build --response "Implemented parser and tests"
+```
 
 ---
 
-## 6) Troubleshooting
+## 7) Daily operating ritual (recommended)
 
-### CLI not found
+1. **Status:** run status command before edits.
+2. **Decide:** choose one phase objective.
+3. **Execute:** make the smallest meaningful change.
+4. **Verify:** run checks/tests.
+5. **Record:** update task/docs/devlog.
 
-- Confirm virtual environment is active.
+This rhythm minimizes drift and protects continuity across sessions.
+
+---
+
+## 8) Common commands
+
+```bash
+mythic-vibe status
+mythic-vibe checkin --phase intent --update "Defined target users and anti-goals"
+mythic-vibe doctor
+mythic-vibe sync
+mythic-vibe method
+```
+
+Ritual aliases may also be available (`mythic imbue`, `mythic evoke`, `mythic scry`, etc.).
+
+---
+
+## 9) Troubleshooting
+
+### CLI command not found
+
+- Ensure virtual environment is active.
 - Re-run `pip install -e .`.
-- Fall back to `python -m mythic_vibe_cli.cli --help`.
+- Use module mode: `python -m mythic_vibe_cli.cli --help`.
 
-### Phase confusion or state mismatch
+### Status or phase mismatch
 
-- Inspect generated artifacts in `docs/`, `tasks/`, and `mythic/`.
-- Re-run the status/check command before making edits.
+- Inspect generated `mythic/`, `docs/`, and `tasks/` artifacts.
+- Run status/doctor commands before additional edits.
 
-### Import/boundary errors
+### Configuration confusion
 
-- Review [Architecture](ARCHITECTURE.md) and [Domain Map](DOMAIN_MAP.md).
-- Ensure runtime code changes stay in `mythic_vibe_cli/` unless an explicit architecture decision says otherwise.
+- Inspect resolved config:
+
+```bash
+mythic-vibe config --path .
+```
+
+- Check environment variables overriding config files.
+
+### Architecture boundary uncertainty
+
+- Read `ARCHITECTURE.md` and `DOMAIN_MAP.md`.
+- Keep runtime edits in `mythic_vibe_cli/` unless explicitly approved by architecture change.
 
 ---
 
-## 7) Next reads
+## 10) Next documents
 
-- [System Vision](SYSTEM_VISION.md)
-- [Architecture](ARCHITECTURE.md)
-- [Domain Map](DOMAIN_MAP.md)
-- [API Reference](api.md)
+- `SYSTEM_VISION.md`
+- `ARCHITECTURE.md`
+- `DOMAIN_MAP.md`
+- `api.md`
+- `INDEX.md`


### PR DESCRIPTION
### Motivation

- Provide durable, repository-wide documentation and navigation so contributors can find authoritative records quickly.
- Reduce documentation drift by formalizing a changelog and consolidating onboarding/architecture guidance.
- Capture the session-level rationale in `DEVLOG.md` while keeping this change set documentation-only and not altering runtime behavior.

### Description

- Rewrote and expanded the root `README.md` into a comprehensive operator and contributor guide with install, quickstart, config, and command orientation.
- Added `CHANGELOG.md` and a canonical docs navigator `docs/INDEX.md`, and expanded the reader-facing hub `docs/index.md`. 
- Substantially expanded core docs: `docs/quickstart.md`, `docs/ARCHITECTURE.md`, `docs/DOMAIN_MAP.md`, `docs/api.md`, and `docs/SYSTEM_VISION.md` to clarify boundaries, contracts, and upkeep protocol. 
- Appended a dated Scribe entry to `DEVLOG.md` documenting the documentation sweep and continuity rationale; no runtime Python modules were modified.

### Testing

- Ran a CLI smoke check with `python -m mythic_vibe_cli.cli --help`, which executed successfully and shows the expected command surface. 
- Ran the full test suite with `pytest -q`, which failed during collection due to pre-existing monorepo-wide import/test conflicts (multiple unrelated modules caused 58 collection errors), indicating the failures are not caused by these markdown-only changes. 
- Verification focus was on docs, CLI help smoke test passed; broader test failures are recorded for separate triage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea127cbee88325acddbb9bcd7c40ee)