### PR TITLE
docs: expand documentation governance, add standards and handoff templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ The format is inspired by Keep a Changelog and uses explicit dates for continuit
 
 - Added `docs/INDEX.md` as a canonical documentation navigation map and upkeep protocol.
 - Added first formal `CHANGELOG.md` to establish release-facing history discipline.
+- Added `docs/DOCUMENTATION_STANDARDS.md` as the durability, drift-control, and update-obligation charter for active docs.
+- Added `docs/SESSION_HANDOFF_TEMPLATE.md` for consistent end-of-session continuity capture.
 
 ### Changed
 
-- Expanded root `README.md` into a comprehensive operator and contributor guide.
-- Expanded `docs/index.md` with role-based reading paths and continuity references.
+- Expanded root `README.md` with explicit documentation governance and continuity obligations.
+- Reworked `docs/index.md` into a compatibility redirect to remove duplicated navigation authority.
 - Expanded `docs/quickstart.md` with first-loop workflow, bridge usage, and troubleshooting.
 - Expanded `docs/ARCHITECTURE.md` with detailed component contracts, risk model, and review checklist.
 - Expanded `docs/DOMAIN_MAP.md` with stricter ownership/dependency boundaries and exception protocol.
 - Expanded `docs/api.md` with module contracts, compatibility policy, and integration examples.
 - Expanded `docs/SYSTEM_VISION.md` with mission detail, UX outcomes, and evolution horizons.
-- Updated `DEVLOG.md` with a dedicated session entry documenting the documentation sweep.
+- Expanded `docs/INDEX.md` into a canonical map with update matrices, maintenance cadence, and quality gates.
+- Updated `DEVLOG.md` with an additional continuity entry for this scribe-level documentation expansion.
 
 ## [2026-04-23]
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -130,3 +130,37 @@ This entry marks the beginning of explicit dual-record discipline:
 The two records should now evolve together when meaningful behavior or governance changes occur.
 
 _May the record hold._
+
+---
+
+## 2026-04-23 — Scribe Invocation: Continuity Charter and Handoff Ritual
+
+**Session:** Focused documentation-governance hardening pass.
+**Status:** Markdown-only updates; repository runtime code untouched.
+**Hands on the wheel:** Eirwyn Rúnblóm, responding to a direct Scribe invocation, polished and expanded the active documentation layer with an emphasis on continuity under interruption.
+
+### What was changed in this pass
+
+- `docs/DOCUMENTATION_STANDARDS.md` was created as a formal charter for writing quality, update obligations, drift detection, and archival discipline.
+- `docs/SESSION_HANDOFF_TEMPLATE.md` was created as a pragmatic close-out template to preserve rationale and next actions between sessions.
+- `docs/INDEX.md` was expanded into a true canonical map with role-based pathways, update matrices, quality gates, and cadence guidance.
+- `docs/index.md` was transformed into a compatibility redirect to prevent duplicate authority and future drift.
+- `README.md` was updated with a dedicated governance section linking the continuity documents.
+- `CHANGELOG.md` was synchronized with this session so user-facing records remain aligned with contributor-facing memory.
+
+### Why this matters now
+
+The earlier documentation sweep made the docs richer; this pass made them more **self-healing**. The project now has explicit rules for how docs remain trustworthy when features, priorities, and maintainers change.
+
+In practical terms, this reduces three recurring failure patterns:
+
+1. **Silent divergence** between command behavior and docs.
+2. **Lost intent** after long pauses or handoffs.
+3. **Navigation decay** caused by duplicated index surfaces.
+
+### Continuity threads left deliberately open
+
+- The broader monorepo still contains a large volume of historical/reference documentation outside the active CLI spine. A future archival curation pass can classify those files as canonical, reference-only, or frozen history.
+- If command surfaces evolve significantly, the next maintainer should validate that `docs/api.md` still matches runtime semantics before release tagging.
+
+_May the memory remain legible when the fire burns low._

--- a/README.md
+++ b/README.md
@@ -179,6 +179,20 @@ Example config:
 
 ---
 
+
+## Documentation governance and continuity
+
+This project now keeps an explicit documentation governance layer to reduce drift in long-lived sessions:
+
+- `docs/INDEX.md` is the canonical documentation map.
+- `docs/DOCUMENTATION_STANDARDS.md` defines writing and update obligations.
+- `docs/SESSION_HANDOFF_TEMPLATE.md` provides a structured end-of-session handoff.
+- `DEVLOG.md` and `CHANGELOG.md` are maintained as paired historical records (narrative + release-facing).
+
+When changing behavior, update docs in the same commit or PR. Treat documentation drift as a functional bug, not an editorial nicety.
+
+---
+
 ## Command overview
 
 Primary command families include:

--- a/docs/DOCUMENTATION_STANDARDS.md
+++ b/docs/DOCUMENTATION_STANDARDS.md
@@ -1,0 +1,204 @@
+# Documentation Standards and Continuity Charter
+
+This charter defines how documentation is written, reviewed, evolved, and archived in the Mythic Vibe CLI repository.
+
+Its purpose is simple: **our records should remain useful after context fades**.
+
+---
+
+## 1) Documentation principles
+
+### 1.1 Durable over fashionable
+
+Write for maintainers who arrive months later, not only for today’s active contributors.
+
+### 1.2 Explain intent, not only mechanics
+
+A command list without rationale causes future drift. Each major file should preserve:
+
+- what exists,
+- why it exists,
+- what assumptions it depends on,
+- what would invalidate it.
+
+### 1.3 One canonical home per topic
+
+If two docs describe the same contract, one is canonical and the other links to it. Duplicate authority invites divergence.
+
+### 1.4 Operational clarity over ornamental language
+
+Poetic framing is welcome, ambiguity is not. Every section should answer a practical question.
+
+### 1.5 Explicit dates and explicit status
+
+Use absolute dates (`YYYY-MM-DD`) in changelog/devlog records and note whether statements are:
+
+- current behavior,
+- planned behavior,
+- historical behavior.
+
+---
+
+## 2) The active documentation spine
+
+These files form the project’s continuity backbone and should be reviewed together when major behavior changes.
+
+- `README.md` — project identity, scope, install, command orientation.
+- `docs/INDEX.md` — canonical navigation and ownership map.
+- `docs/quickstart.md` — first-loop execution guide.
+- `docs/ARCHITECTURE.md` — component model and dependency boundaries.
+- `docs/api.md` — public CLI contracts and compatibility expectations.
+- `docs/DOMAIN_MAP.md` — ownership and boundary registry.
+- `docs/SYSTEM_VISION.md` — long-horizon purpose and non-goals.
+- `DEVLOG.md` — narrative continuity for contributors.
+- `CHANGELOG.md` — release/user-facing delta log.
+
+When one file changes and the others become stale, drift has begun.
+
+---
+
+## 3) Writing conventions
+
+### 3.1 Required section pattern for major docs
+
+For architecture/API/vision/policy documents, prefer this section order:
+
+1. **Purpose**
+2. **Scope (in and out)**
+3. **Current state**
+4. **Contracts/invariants**
+5. **Failure modes and risks**
+6. **Operational checklist**
+7. **References / related docs**
+
+### 3.2 Language conventions
+
+- Prefer active voice.
+- Expand acronyms on first use.
+- Avoid vague terms like “soon,” “later,” or “obvious.”
+- Use consistent product naming: **Mythic Vibe CLI**.
+
+### 3.3 Code and command blocks
+
+Every command example should be copy-paste safe and indicate context when needed:
+
+- shell required,
+- working directory assumptions,
+- expected artifact output.
+
+### 3.4 Compatibility statements
+
+Where behavior can change, include a “Compatibility” subsection clarifying:
+
+- what is stable,
+- what is experimental,
+- deprecation path expectations.
+
+---
+
+## 4) Review and update rhythm
+
+### 4.1 Trigger events that require doc updates
+
+A documentation update is required when any of the following occurs:
+
+- new command or option added,
+- command semantics changed,
+- file layout or scaffold output changed,
+- compatibility/deprecation policy changed,
+- build/test workflow changed,
+- major strategic direction changed.
+
+### 4.2 Minimum update set by change type
+
+- **CLI behavior change**: `README.md`, `docs/api.md`, `CHANGELOG.md`.
+- **Scaffold/template change**: `docs/quickstart.md`, `docs/ARCHITECTURE.md`, `CHANGELOG.md`.
+- **Governance/direction change**: `docs/SYSTEM_VISION.md`, `DEVLOG.md`, `CHANGELOG.md`.
+- **Boundary/ownership change**: `docs/DOMAIN_MAP.md`, `docs/INDEX.md`, `DEVLOG.md`.
+
+### 4.3 Session closure checklist
+
+Before ending a meaningful session, confirm:
+
+- decision rationale is written,
+- command contract changes are documented,
+- open questions are captured as explicit threads,
+- index links still resolve,
+- changelog/devlog entries are synchronized.
+
+---
+
+## 5) Drift detection and repair
+
+### 5.1 Common drift signals
+
+- docs promise commands that no longer exist,
+- defaults in docs do not match runtime behavior,
+- two files disagree on project scope,
+- troubleshooting sections reference removed paths.
+
+### 5.2 Drift response protocol
+
+1. Identify canonical source for the contested topic.
+2. Align non-canonical docs to canonical wording.
+3. Add an entry in `DEVLOG.md` summarizing what drift was repaired.
+4. Add a user-facing note in `CHANGELOG.md` if behavior understanding changed.
+
+---
+
+## 6) Session memory and archival discipline
+
+### 6.1 DEVLOG expectations
+
+Each devlog entry should preserve:
+
+- date,
+- session intention,
+- what changed,
+- why it matters,
+- unresolved threads.
+
+### 6.2 CHANGELOG expectations
+
+Changelog entries should be concise, externally useful, and grouped by semantic categories (`Added`, `Changed`, `Fixed`, `Removed`, etc.).
+
+### 6.3 Archival notes
+
+When superseding a document:
+
+- avoid silent deletion,
+- leave a forwarding note or replacement link,
+- preserve historical context in the devlog.
+
+---
+
+## 7) Documentation quality rubric
+
+A mature document should score “yes” to all checks below:
+
+- **Findable** — appears in `docs/INDEX.md`.
+- **Scoped** — explicitly states what it covers and excludes.
+- **Actionable** — gives clear next actions.
+- **Consistent** — terminology and contracts match peer docs.
+- **Dated** — when temporal claims are made, dates are explicit.
+- **Maintainable** — includes enough structure for easy future edits.
+
+---
+
+## 8) Practical ownership model
+
+Ownership is functional, not personal:
+
+- whoever changes behavior is responsible for initiating doc updates,
+- reviewers are responsible for drift checks,
+- maintainers are responsible for continuity and archival coherence.
+
+If ownership is unclear, default to updating docs rather than deferring.
+
+---
+
+## 9) Closing commitment
+
+This repository may evolve quickly, but its memory should remain deliberate.
+
+If code is the blade, documentation is the sheath: it preserves shape, protects intent, and keeps craft from rusting between sessions.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,86 +1,125 @@
-# Mythic Vibe CLI Documentation Hub
+# Mythic Vibe CLI Documentation Index (Canonical)
 
-Welcome to the active documentation hub for **Mythic Vibe CLI**, a method-driven command-line system for building software with explicit phases, durable artifacts, and cleaner collaboration handoffs.
+This file is the canonical navigation and maintenance map for the active Mythic Vibe CLI documentation suite.
 
-If you are new, begin with `quickstart.md`. If you are contributing, begin with `ARCHITECTURE.md` and `DOMAIN_MAP.md`.
-
-> Canonical navigation map: `docs/INDEX.md`.
+If two indexes disagree, this one wins.
 
 ---
 
-## What this project does
+## 1) Purpose of this index
 
-Mythic Vibe CLI helps builders move from idea to implementation via a repeatable engineering loop:
+This repository contains multiple code and research domains, but not all of them are active product runtime surfaces. This index helps contributors answer three questions quickly:
 
-`intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
-
-Rather than relying on memory alone, the CLI writes structured artifacts so sessions can pause and resume without losing rationale.
-
----
-
-## Documentation map
-
-### Start here
-
-1. **[Quickstart](quickstart.md)**  
-   Installation, setup, first operational loop, and troubleshooting.
-2. **[System Vision](SYSTEM_VISION.md)**  
-   Product goals, promises, anti-goals, and evolution strategy.
-3. **[Architecture](ARCHITECTURE.md)**  
-   Active runtime boundaries, component responsibilities, and dependency direction.
-
-### Governance and boundaries
-
-- **[Domain Map](DOMAIN_MAP.md)** — authoritative ownership map for active vs dormant domains.
-- **[API Reference](api.md)** — CLI/module interfaces and filesystem contracts.
-- **[Hardware Profiles](hardware_profiles.md)** — execution guidance for constrained and high-end environments.
-
-### Continuity and release history
-
-- **[Root DEVLOG](../DEVLOG.md)** — chronological record of meaningful decisions and sessions.
-- **[Root CHANGELOG](../CHANGELOG.md)** — release-facing summary of what changed and why it matters.
+1. Which documents are authoritative for the CLI today?
+2. Which documents are contextual/reference material?
+3. What must be updated when behavior changes?
 
 ---
 
-## Recommended reading paths
+## 2) Fast-start reading paths
 
-### Path A — First-time user (10–15 minutes)
+### New user (first 15 minutes)
 
-1. Read [Quickstart](quickstart.md).
-2. Run one complete phase loop.
-3. Skim [System Vision](SYSTEM_VISION.md).
-4. Bookmark [API Reference](api.md) for commands and contracts.
+1. [quickstart.md](quickstart.md)
+2. [api.md](api.md)
+3. [SYSTEM_VISION.md](SYSTEM_VISION.md)
 
-### Path B — Contributor (20–30 minutes)
+### Contributor (first 30 minutes)
 
-1. Read [Architecture](ARCHITECTURE.md).
-2. Read [Domain Map](DOMAIN_MAP.md).
-3. Read [API Reference](api.md).
-4. Review [Root DEVLOG](../DEVLOG.md) for recent decisions.
+1. [ARCHITECTURE.md](ARCHITECTURE.md)
+2. [DOMAIN_MAP.md](DOMAIN_MAP.md)
+3. [DOCUMENTATION_STANDARDS.md](DOCUMENTATION_STANDARDS.md)
+4. [../DEVLOG.md](../DEVLOG.md)
 
-### Path C — Maintainer / release owner
+### Maintainer / release steward
 
-1. Review [Root CHANGELOG](../CHANGELOG.md).
-2. Validate docs remain synchronized with behavior.
-3. Verify boundary and dependency rules before merge.
-
----
-
-## Documentation discipline
-
-When behavior changes, update documentation in the same PR:
-
-- Behavior or command contract changes -> `api.md` and/or `quickstart.md`
-- Architecture or flow changes -> `ARCHITECTURE.md`
-- Ownership/boundary changes -> `DOMAIN_MAP.md`
-- Product intent changes -> `SYSTEM_VISION.md` and `README.md`
-- Session continuity context -> `DEVLOG.md`
-- User-facing release summary -> `CHANGELOG.md`
-
-If docs and behavior diverge, treat it as a bug.
+1. [../CHANGELOG.md](../CHANGELOG.md)
+2. [DOCUMENTATION_STANDARDS.md](DOCUMENTATION_STANDARDS.md)
+3. [SESSION_HANDOFF_TEMPLATE.md](SESSION_HANDOFF_TEMPLATE.md)
+4. [../README.md](../README.md)
 
 ---
 
-## Active product status note
+## 3) Active documentation spine
 
-This repository is a multi-project monorepo. The active product runtime path is **`mythic_vibe_cli/`**. Other trees include research material, vendor mirrors, and isolated historical/runtime experiments.
+| Document | Primary audience | Core responsibility |
+|---|---|---|
+| `../README.md` | users + contributors | project posture, install flow, command orientation |
+| `quickstart.md` | users | first operational loop and troubleshooting |
+| `ARCHITECTURE.md` | contributors | component boundaries and dependency law |
+| `api.md` | integrators + maintainers | command contracts and compatibility expectations |
+| `DOMAIN_MAP.md` | maintainers | ownership boundaries and escalation path |
+| `SYSTEM_VISION.md` | product/maintainers | strategic scope, non-goals, long-horizon direction |
+| `DOCUMENTATION_STANDARDS.md` | all contributors | writing quality, drift control, continuity protocol |
+| `SESSION_HANDOFF_TEMPLATE.md` | session owners | structured closure and handoff continuity |
+| `../DEVLOG.md` | contributors | narrative why-history and decision lineage |
+| `../CHANGELOG.md` | users/release owners | externally meaningful change history |
+
+---
+
+## 4) Update obligations by change type
+
+When you change behavior, update the matching documents in the same PR.
+
+| Change type | Required doc updates |
+|---|---|
+| CLI command added/changed | `api.md`, `../README.md`, `../CHANGELOG.md` |
+| Scaffolding behavior changed | `quickstart.md`, `ARCHITECTURE.md`, `../CHANGELOG.md` |
+| Config precedence/defaults changed | `api.md`, `quickstart.md`, `../README.md` |
+| Domain ownership moved | `DOMAIN_MAP.md`, `ARCHITECTURE.md`, `../DEVLOG.md` |
+| Strategy/mission shift | `SYSTEM_VISION.md`, `../README.md`, `../DEVLOG.md`, `../CHANGELOG.md` |
+| Documentation process change | `DOCUMENTATION_STANDARDS.md`, `SESSION_HANDOFF_TEMPLATE.md` |
+
+If behavior and documentation diverge, treat it as a defect.
+
+---
+
+## 5) Canonical vs reference surfaces
+
+### Canonical runtime docs (actively maintained)
+
+- This `docs/` core set
+- Root `README.md`
+- Root `DEVLOG.md`
+- Root `CHANGELOG.md`
+
+### Reference/spec archive (contextual; not always runtime-authoritative)
+
+- `docs/specs/` and other long-form concept packs
+- root-level historic/essay documents not tied to active command contracts
+
+When in doubt, prioritize active runtime docs for operational truth.
+
+---
+
+## 6) Documentation quality gate (pre-merge)
+
+Before merging a behavior-changing PR, confirm:
+
+- [ ] changed commands are reflected in `api.md`
+- [ ] onboarding impact reflected in `quickstart.md` or `README.md`
+- [ ] user-facing deltas logged in `CHANGELOG.md`
+- [ ] rationale captured in `DEVLOG.md` when decisions are non-trivial
+- [ ] links in this index still resolve
+
+---
+
+## 7) Continuity cadence
+
+Recommended maintenance rhythm:
+
+- **Every feature PR:** update contracts + changelog notes
+- **Every significant session:** append devlog entry
+- **Weekly/periodic:** run quick drift sweep across core docs
+- **Before release cut:** ensure index, changelog, and README alignment
+
+---
+
+## 8) Related records
+
+- [Documentation Standards and Continuity Charter](DOCUMENTATION_STANDARDS.md)
+- [Session Handoff Template](SESSION_HANDOFF_TEMPLATE.md)
+- [Project DEVLOG](../DEVLOG.md)
+- [Project CHANGELOG](../CHANGELOG.md)
+
+A good index does not merely list files; it protects memory by showing where truth lives.

--- a/docs/SESSION_HANDOFF_TEMPLATE.md
+++ b/docs/SESSION_HANDOFF_TEMPLATE.md
@@ -1,0 +1,91 @@
+# Session Handoff Template
+
+Use this template at the end of substantial work sessions to preserve continuity for the next contributor.
+
+---
+
+## Session metadata
+
+- **Date (UTC):**
+- **Branch:**
+- **Primary objective:**
+- **Session type:** (implementation / refactor / documentation / investigation / triage)
+
+---
+
+## What changed
+
+Summarize concrete modifications in plain language.
+
+- Files modified:
+- Commands executed:
+- Tests/checks run:
+- Artifacts produced:
+
+---
+
+## Why these changes were made
+
+Capture rationale, tradeoffs, and constraints.
+
+- Decision drivers:
+- Alternatives considered:
+- Risks accepted:
+
+---
+
+## Current repository state
+
+- Working tree status:
+- Known unstable areas:
+- Open TODOs intentionally deferred:
+
+---
+
+## Validation summary
+
+List checks with pass/fail status and key output.
+
+- [ ] Unit tests
+- [ ] Linting/formatting
+- [ ] Smoke run of changed commands
+- [ ] Documentation synchronization
+
+Notes:
+
+---
+
+## Continuity threads for next session
+
+Record unresolved questions as explicit prompts.
+
+1.
+2.
+3.
+
+---
+
+## Documentation sync checklist
+
+Before closing:
+
+- [ ] `DEVLOG.md` updated with date and rationale
+- [ ] `CHANGELOG.md` updated if user-facing behavior shifted
+- [ ] `docs/INDEX.md` updated for new/moved docs
+- [ ] Cross-links checked
+- [ ] Deprecated claims removed or marked historical
+
+---
+
+## Optional: paste-ready handoff note
+
+```md
+### Handoff Summary
+Date: <YYYY-MM-DD>
+Objective: <one line>
+Completed: <bullets>
+Deferred: <bullets>
+Next recommended step: <one line>
+```
+
+This template is intentionally concise so it gets used. Precision is better than volume; continuity is better than silence.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,86 +1,15 @@
-# Mythic Vibe CLI Documentation Hub
+# Documentation Hub (Compatibility Entry)
 
-Welcome to the active documentation hub for **Mythic Vibe CLI**, a method-driven command-line system for building software with explicit phases, durable artifacts, and cleaner collaboration handoffs.
+This file exists as a compatibility-friendly lowercase entry point.
 
-If you are new, begin with `quickstart.md`. If you are contributing, begin with `ARCHITECTURE.md` and `DOMAIN_MAP.md`.
+For canonical navigation, maintenance rules, and update obligations, use:
 
-> Canonical navigation map: `docs/INDEX.md`.
-
----
-
-## What this project does
-
-Mythic Vibe CLI helps builders move from idea to implementation via a repeatable engineering loop:
-
-`intent -> constraints -> architecture -> plan -> build -> verify -> reflect`
-
-Rather than relying on memory alone, the CLI writes structured artifacts so sessions can pause and resume without losing rationale.
+- **[docs/INDEX.md](INDEX.md)**
 
 ---
 
-## Documentation map
+## Why this file is intentionally short
 
-### Start here
+Historically, both `docs/index.md` and `docs/INDEX.md` contained full navigation content. That duplication increased drift risk. The repository now treats `docs/INDEX.md` as canonical, while this file remains as a stable redirect for tooling and human habit.
 
-1. **[Quickstart](quickstart.md)**  
-   Installation, setup, first operational loop, and troubleshooting.
-2. **[System Vision](SYSTEM_VISION.md)**  
-   Product goals, promises, anti-goals, and evolution strategy.
-3. **[Architecture](ARCHITECTURE.md)**  
-   Active runtime boundaries, component responsibilities, and dependency direction.
-
-### Governance and boundaries
-
-- **[Domain Map](DOMAIN_MAP.md)** — authoritative ownership map for active vs dormant domains.
-- **[API Reference](api.md)** — CLI/module interfaces and filesystem contracts.
-- **[Hardware Profiles](hardware_profiles.md)** — execution guidance for constrained and high-end environments.
-
-### Continuity and release history
-
-- **[Root DEVLOG](../DEVLOG.md)** — chronological record of meaningful decisions and sessions.
-- **[Root CHANGELOG](../CHANGELOG.md)** — release-facing summary of what changed and why it matters.
-
----
-
-## Recommended reading paths
-
-### Path A — First-time user (10–15 minutes)
-
-1. Read [Quickstart](quickstart.md).
-2. Run one complete phase loop.
-3. Skim [System Vision](SYSTEM_VISION.md).
-4. Bookmark [API Reference](api.md) for commands and contracts.
-
-### Path B — Contributor (20–30 minutes)
-
-1. Read [Architecture](ARCHITECTURE.md).
-2. Read [Domain Map](DOMAIN_MAP.md).
-3. Read [API Reference](api.md).
-4. Review [Root DEVLOG](../DEVLOG.md) for recent decisions.
-
-### Path C — Maintainer / release owner
-
-1. Review [Root CHANGELOG](../CHANGELOG.md).
-2. Validate docs remain synchronized with behavior.
-3. Verify boundary and dependency rules before merge.
-
----
-
-## Documentation discipline
-
-When behavior changes, update documentation in the same PR:
-
-- Behavior or command contract changes -> `api.md` and/or `quickstart.md`
-- Architecture or flow changes -> `ARCHITECTURE.md`
-- Ownership/boundary changes -> `DOMAIN_MAP.md`
-- Product intent changes -> `SYSTEM_VISION.md` and `README.md`
-- Session continuity context -> `DEVLOG.md`
-- User-facing release summary -> `CHANGELOG.md`
-
-If docs and behavior diverge, treat it as a bug.
-
----
-
-## Active product status note
-
-This repository is a multi-project monorepo. The active product runtime path is **`mythic_vibe_cli/`**. Other trees include research material, vendor mirrors, and isolated historical/runtime experiments.
+If you were linked here from external notes, continue through `INDEX.md`.


### PR DESCRIPTION
### Motivation
- Reduce documentation drift and establish a single authoritative documentation control plane for the active product surface. 
- Preserve session continuity and decision rationale so future contributors can resume work without reconstructing intent. 
- Provide explicit, copy-pasteable writing and update obligations to make doc maintenance a first-class part of the development workflow.

### Description
- Added a formal documentation charter at `docs/DOCUMENTATION_STANDARDS.md` that defines principles, required sections, update obligations, drift detection/repair, and a quality rubric. 
- Added a session close-out template at `docs/SESSION_HANDOFF_TEMPLATE.md` to capture metadata, changes, validation, and explicit continuity threads. 
- Expanded `docs/INDEX.md` into a canonical documentation index with role-based reading paths, update matrices, pre-merge quality gates, and maintenance cadence, and converted `docs/index.md` into a compatibility redirect to avoid duplicated authority. 
- Updated root-level documentation to surface the governance layer by adding a documentation-governance section to `README.md`, and synchronized narrative and release records in `DEVLOG.md` and `CHANGELOG.md` to reflect the documentation expansion.

### Testing
- Ran `git diff --check` to validate whitespace and diff hygiene and it succeeded. 
- Ran the test suite with `python -m pytest tests -q` which returned `10 passed` and no failures. 
- This PR is documentation-only and did not modify runtime source logic, so no additional runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea17cfac108325b7b0ca19276b0dc7)